### PR TITLE
CommercioID improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/commercionetwork/commercionetwork
 go 1.12
 
 require (
-		github.com/cosmos/cosmos-sdk v0.28.2-0.20190826165445-eeb847c8455b
+        github.com/cosmos/cosmos-sdk v0.28.2-0.20190826165445-eeb847c8455b
 	github.com/gorilla/mux v1.7.0
 	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/spf13/afero v1.2.2 // indirect

--- a/x/docs/client/cli/tx.go
+++ b/x/docs/client/cli/tx.go
@@ -105,11 +105,11 @@ func GetCmdSendDocumentReceipt(cdc *codec.Codec) *cobra.Command {
 			}
 
 			receipt := types.DocumentReceipt{
-				Sender:    sender,
-				Recipient: recipient,
-				TxHash:    args[1],
-				Uuid:      args[2],
-				Proof:     args[3],
+				Sender:       sender,
+				Recipient:    recipient,
+				TxHash:       args[1],
+				DocumentUuid: args[2],
+				Proof:        args[3],
 			}
 
 			msg := types.NewMsgDocumentReceipt(receipt)

--- a/x/docs/genesis.go
+++ b/x/docs/genesis.go
@@ -1,26 +1,62 @@
 package docs
 
 import (
+	"github.com/commercionetwork/commercionetwork/x/docs/internal/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-/**
-THIS FILE IS USELESS BUT IT HELPS ME REMEMBER THIS FILE STRUCTURE IN ORDER TO USE IT IN FUTURE MODULES
-*/
-
-type GenesisState struct {
+type UserDocumentsData struct {
+	User              sdk.AccAddress         `json:"user"`
+	SentDocuments     types.Documents        `json:"sent_documents"`
+	ReceivedDocuments types.Documents        `json:"received_documents"`
+	SentReceipts      types.DocumentReceipts `json:"sent_receipts"`
+	ReceivedReceipts  types.DocumentReceipts `json:"received_receipts"`
 }
 
+// GenesisState - docs genesis state
+type GenesisState struct {
+	UsersData []UserDocumentsData `json:"users_data"`
+}
+
+// DefaultGenesisState returns a default genesis state
 func DefaultGenesisState() GenesisState {
 	return GenesisState{}
 }
 
-func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {}
-
-func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
-	return DefaultGenesisState()
+// InitGenesis sets docs information for genesis.
+func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {
+	for _, data := range data.UsersData {
+		keeper.SetUserDocuments(ctx, data.User, data.SentDocuments, data.ReceivedDocuments)
+		keeper.SetUserReceipts(ctx, data.User, data.SentReceipts, data.ReceivedReceipts)
+	}
 }
 
-func ValidateGenesis(data GenesisState) error {
+// ExportGenesis returns a GenesisState for a given context and keeper.
+func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
+	users, err := keeper.GetUsersSet(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	var usersData []UserDocumentsData
+	for _, user := range users {
+		userData := UserDocumentsData{
+			User:              user,
+			SentDocuments:     keeper.GetUserSentDocuments(ctx, user),
+			ReceivedDocuments: keeper.GetUserReceivedDocuments(ctx, user),
+			SentReceipts:      keeper.GetUserSentReceipts(ctx, user),
+			ReceivedReceipts:  keeper.GetUserReceivedReceipts(ctx, user),
+		}
+		usersData = append(usersData, userData)
+	}
+
+	return GenesisState{
+		UsersData: usersData,
+	}
+}
+
+// ValidateGenesis performs basic validation of genesis data returning an
+// error for any failed validation criteria.
+func ValidateGenesis(_ GenesisState) error {
 	return nil
 }

--- a/x/docs/internal/keeper/keeper_test.go
+++ b/x/docs/internal/keeper/keeper_test.go
@@ -51,9 +51,16 @@ func TestKeeper_ShareDocument_ExistingDocument(t *testing.T) {
 
 func TestKeeper_ShareDocument_SameInfoDifferentRecipient(t *testing.T) {
 	documents := types.Documents{TestingDocument}
+
 	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
-	store.Set([]byte(types.SentDocumentsPrefix+TestingSender.String()), TestUtils.Cdc.MustMarshalBinaryBare(&documents))
-	store.Set([]byte(types.ReceivedDocumentsPrefix+TestingRecipient.String()), TestUtils.Cdc.MustMarshalBinaryBare(&documents))
+	store.Set(
+		TestUtils.DocsKeeper.getSentDocumentsStoreKey(TestingDocument.Sender),
+		TestUtils.Cdc.MustMarshalBinaryBare(&documents),
+	)
+	store.Set(
+		TestUtils.DocsKeeper.getReceivedDocumentsStoreKey(TestingDocument.Recipient),
+		TestUtils.Cdc.MustMarshalBinaryBare(&documents),
+	)
 
 	newRecipient, _ := sdk.AccAddressFromBech32("cosmos1h2z8u9294gtqmxlrnlyfueqysng3krh009fum7")
 	newDocument := types.Document{
@@ -65,9 +72,9 @@ func TestKeeper_ShareDocument_SameInfoDifferentRecipient(t *testing.T) {
 	}
 	TestUtils.DocsKeeper.ShareDocument(TestUtils.Ctx, newDocument)
 
-	sentDocsBz := store.Get([]byte(types.SentDocumentsPrefix + TestingSender.String()))
-	receivedDocsBz := store.Get([]byte(types.ReceivedDocumentsPrefix + TestingRecipient.String()))
-	newReceivedDocsBz := store.Get([]byte(types.ReceivedDocumentsPrefix + newRecipient.String()))
+	sentDocsBz := store.Get(TestUtils.DocsKeeper.getSentDocumentsStoreKey(TestingDocument.Sender))
+	receivedDocsBz := store.Get(TestUtils.DocsKeeper.getReceivedDocumentsStoreKey(TestingDocument.Recipient))
+	newReceivedDocsBz := store.Get(TestUtils.DocsKeeper.getReceivedDocumentsStoreKey(newRecipient))
 
 	var sentDocs, receivedDocs, newReceivedDocs types.Documents
 	TestUtils.Cdc.MustUnmarshalBinaryBare(sentDocsBz, &sentDocs)
@@ -127,40 +134,41 @@ func TestKeeper_GetUserSentDocuments_NonEmptyList(t *testing.T) {
 // ----------------------------------
 
 func TestKeeper_SendDocumentReceipt_EmptyList(t *testing.T) {
+	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
+	store.Delete(TestUtils.DocsKeeper.getSentReceiptsStoreKey(TestingDocumentReceipt.Sender))
+
 	TestUtils.DocsKeeper.SendDocumentReceipt(TestUtils.Ctx, TestingDocumentReceipt)
 
-	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
-	docReceiptBz := store.Get([]byte(types.DocumentReceiptPrefix + TestingDocumentReceipt.Uuid +
-		TestingDocumentReceipt.Sender.String()))
+	var stored types.DocumentReceipts
+	docReceiptBz := store.Get(TestUtils.DocsKeeper.getSentReceiptsStoreKey(TestingDocumentReceipt.Sender))
+	TestUtils.Cdc.MustUnmarshalBinaryBare(docReceiptBz, &stored)
 
-	var actual types.DocumentReceipt
-
-	TestUtils.Cdc.MustUnmarshalBinaryBare(docReceiptBz, &actual)
-
-	assert.Equal(t, TestingDocumentReceipt, actual)
+	assert.Equal(t, 1, len(stored))
+	assert.Equal(t, types.DocumentReceipts{TestingDocumentReceipt}, stored)
 }
 
 func TestKeeper_SendDocumentReceipt_ExistingReceipt(t *testing.T) {
-	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
+	var existing = types.DocumentReceipts{TestingDocumentReceipt}
 
-	store.Set([]byte(types.DocumentReceiptPrefix+TestingDocumentReceipt.Uuid+TestingDocumentReceipt.Sender.String()),
-		TestUtils.Cdc.MustMarshalBinaryBare(TestingDocumentReceipt))
+	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
+	store.Set(
+		TestUtils.DocsKeeper.getSentReceiptsStoreKey(TestingDocumentReceipt.Sender),
+		TestUtils.Cdc.MustMarshalBinaryBare(&existing),
+	)
 
 	TestUtils.DocsKeeper.SendDocumentReceipt(TestUtils.Ctx, TestingDocumentReceipt)
 
-	var counter = 0
-	iterator := sdk.KVStorePrefixIterator(store, []byte(types.DocumentReceiptPrefix))
-	for ; iterator.Valid(); iterator.Next() {
-		counter++
-	}
+	var stored types.DocumentReceipts
+	docReceiptBz := store.Get(TestUtils.DocsKeeper.getSentReceiptsStoreKey(TestingDocumentReceipt.Sender))
+	TestUtils.Cdc.MustUnmarshalBinaryBare(docReceiptBz, &stored)
 
-	assert.Equal(t, 1, counter)
+	assert.Equal(t, 1, len(stored))
+	assert.Equal(t, existing, stored)
 }
 
 func TestKeeper_GetUserReceivedReceipts_EmptyList(t *testing.T) {
-
 	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
-	store.Delete([]byte(types.DocumentReceiptPrefix + TestingDocumentReceipt.Uuid + TestingDocumentReceipt.Sender.String()))
+	store.Delete(TestUtils.DocsKeeper.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient))
 
 	receipts := TestUtils.DocsKeeper.GetUserReceivedReceipts(TestUtils.Ctx, TestingDocumentReceipt.Recipient)
 
@@ -168,16 +176,17 @@ func TestKeeper_GetUserReceivedReceipts_EmptyList(t *testing.T) {
 }
 
 func TestKeeper_GetUserReceivedReceipts_FilledList(t *testing.T) {
-
-	var expectedReceipts = types.DocumentReceipts{TestingDocumentReceipt}
+	var existing = types.DocumentReceipts{TestingDocumentReceipt}
 
 	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
-	store.Set([]byte(types.DocumentReceiptPrefix+TestingDocumentReceipt.Uuid+TestingDocumentReceipt.Sender.String()),
-		TestUtils.Cdc.MustMarshalBinaryBare(&TestingDocumentReceipt))
+	store.Set(
+		TestUtils.DocsKeeper.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient),
+		TestUtils.Cdc.MustMarshalBinaryBare(&existing),
+	)
 
 	actualReceipts := TestUtils.DocsKeeper.GetUserReceivedReceipts(TestUtils.Ctx, TestingDocumentReceipt.Recipient)
 
-	assert.Equal(t, expectedReceipts, actualReceipts)
+	assert.Equal(t, existing, actualReceipts)
 }
 
 func TestKeeper_GetUserReceivedReceiptsForDocument_UuidNotFound(t *testing.T) {
@@ -187,23 +196,26 @@ func TestKeeper_GetUserReceivedReceiptsForDocument_UuidNotFound(t *testing.T) {
 
 func TestKeeper_GetUserReceivedReceiptsForDocument_UuidFound(t *testing.T) {
 	var TestingDocumentReceipt2 = types.DocumentReceipt{
-		Sender:    TestingSender2,
-		Recipient: TestingRecipient,
-		TxHash:    "txHash",
-		Uuid:      "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
-		Proof:     "proof",
+		Sender:       TestingSender2,
+		Recipient:    TestingDocumentReceipt.Recipient,
+		TxHash:       TestingDocumentReceipt.TxHash,
+		DocumentUuid: TestingDocumentReceipt.DocumentUuid,
+		Proof:        TestingDocumentReceipt.Proof,
 	}
 
-	expected := types.DocumentReceipts{TestingDocumentReceipt, TestingDocumentReceipt2}
+	stored := types.DocumentReceipts{TestingDocumentReceipt, TestingDocumentReceipt2}
 
 	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
-	store.Set([]byte(types.DocumentReceiptPrefix+TestingDocumentReceipt.Uuid+TestingDocumentReceipt.Sender.String()),
-		TestUtils.Cdc.MustMarshalBinaryBare(TestingDocumentReceipt))
-	store.Set([]byte(types.DocumentReceiptPrefix+TestingDocumentReceipt2.Uuid+TestingDocumentReceipt2.Sender.String()),
-		TestUtils.Cdc.MustMarshalBinaryBare(TestingDocumentReceipt2))
+	store.Set(
+		TestUtils.DocsKeeper.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient),
+		TestUtils.Cdc.MustMarshalBinaryBare(&stored),
+	)
 
-	actual := TestUtils.DocsKeeper.GetUserReceivedReceiptsForDocument(TestUtils.Ctx, TestingDocumentReceipt.Recipient,
-		TestingDocumentReceipt.Uuid)
+	actual := TestUtils.DocsKeeper.GetUserReceivedReceiptsForDocument(
+		TestUtils.Ctx,
+		TestingDocumentReceipt.Recipient,
+		TestingDocumentReceipt.DocumentUuid,
+	)
 
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, stored, actual)
 }

--- a/x/docs/internal/keeper/querier_test.go
+++ b/x/docs/internal/keeper/querier_test.go
@@ -55,40 +55,42 @@ func Test_queryGetSentDocuments(t *testing.T) {
 // ----------------------------------
 
 func Test_GetUserReceivedReceipts(t *testing.T) {
+	// Setup the store
+	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
+	store.Delete(TestUtils.DocsKeeper.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient))
 
-	receiptStore := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
-
-	//cleanup the store
-	receiptStore.Delete([]byte(types.DocumentReceiptPrefix + TestingDocumentReceipt.Uuid + TestingSender2.String()))
-
-	//Setup the store
-	receiptStore.Set([]byte(types.DocumentReceiptPrefix+TestingDocumentReceipt.Uuid+TestingDocumentReceipt.Sender.String()),
-		TestUtils.Cdc.MustMarshalBinaryBare(&TestingDocumentReceipt))
-
-	var expected = types.DocumentReceipts{TestingDocumentReceipt}
+	var stored = types.DocumentReceipts{TestingDocumentReceipt}
+	store.Set(
+		TestUtils.DocsKeeper.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient),
+		TestUtils.Cdc.MustMarshalBinaryBare(&stored),
+	)
 
 	// Compose the path
 	path := []string{"receipts", TestingDocumentReceipt.Recipient.String(), ""}
 
-	//Get the returned receipts
+	// Get the returned receipts
 	var actual types.DocumentReceipts
 	actualBz, _ := querier(TestUtils.Ctx, path, request)
 	TestUtils.Cdc.MustUnmarshalJSON(actualBz, &actual)
 
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, stored, actual)
 }
 
 func Test_GetUserReceivedReceiptsForDocument(t *testing.T) {
+	// Setup the store
+	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
+	store.Delete(TestUtils.DocsKeeper.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient))
 
-	//Setup the store
-	receiptStore := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
-	receiptStore.Set([]byte(types.DocumentReceiptPrefix+TestingDocumentReceipt.Uuid+TestingDocumentReceipt.Sender.String()),
-		TestUtils.Cdc.MustMarshalBinaryBare(&TestingDocumentReceipt))
+	var stored = types.DocumentReceipts{TestingDocumentReceipt}
+	store.Set(
+		TestUtils.DocsKeeper.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient),
+		TestUtils.Cdc.MustMarshalBinaryBare(&stored),
+	)
 
 	// Compose the path
-	path := []string{"receipts", TestingDocumentReceipt.Recipient.String(), TestingDocumentReceipt.Uuid}
+	path := []string{"receipts", TestingDocumentReceipt.Recipient.String(), TestingDocumentReceipt.DocumentUuid}
 
-	//Get the returned receipts
+	// Get the returned receipts
 	var actual types.DocumentReceipts
 	actualBz, _ := querier(TestUtils.Ctx, path, request)
 	TestUtils.Cdc.MustUnmarshalJSON(actualBz, &actual)

--- a/x/docs/internal/keeper/test_commons.go
+++ b/x/docs/internal/keeper/test_commons.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/params"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
@@ -19,8 +18,6 @@ var TestUtils = setupTestInput()
 type testInput struct {
 	Cdc        *codec.Codec
 	Ctx        sdk.Context
-	accKeeper  auth.AccountKeeper
-	bankKeeper bank.BaseKeeper
 	DocsKeeper Keeper
 }
 
@@ -47,21 +44,13 @@ func setupTestInput() testInput {
 	ms.MountStoreWithDB(keyDOCS, sdk.StoreTypeIAVL, memDB)
 	_ = ms.LoadLatestVersion()
 
-	pk := params.NewKeeper(cdc, keyParams, tkeyParams, params.DefaultCodespace)
-	ak := auth.NewAccountKeeper(cdc, authKey, pk.Subspace(auth.DefaultParamspace), auth.ProtoBaseAccount)
-	bk := bank.NewBaseKeeper(ak, pk.Subspace(bank.DefaultParamspace), bank.DefaultCodespace, map[string]bool{})
-
 	ctx := sdk.NewContext(ms, abci.Header{ChainID: "test-chain-id"}, false, log.NewNopLogger())
 
 	dck := NewKeeper(keyDOCS, cdc)
 
-	ak.SetParams(ctx, auth.DefaultParams())
-
 	return testInput{
 		Cdc:        cdc,
 		Ctx:        ctx,
-		accKeeper:  ak,
-		bankKeeper: bk,
 		DocsKeeper: dck,
 	}
 }
@@ -102,9 +91,9 @@ var TestingDocument = types.Document{
 }
 
 var TestingDocumentReceipt = types.DocumentReceipt{
-	Sender:    TestingSender,
-	Recipient: TestingRecipient,
-	TxHash:    "txHash",
-	Uuid:      "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
-	Proof:     "proof",
+	Sender:       TestingSender,
+	Recipient:    TestingRecipient,
+	TxHash:       "txHash",
+	DocumentUuid: "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
+	Proof:        "proof",
 }

--- a/x/docs/internal/types/accounts.go
+++ b/x/docs/internal/types/accounts.go
@@ -1,0 +1,20 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Addresses is an alias for a list of sdk.AccAddress that
+// enables custom operations
+type Addresses []sdk.AccAddress
+
+// AppendIfMissing returns a new Addresses instance containing the given
+// address if it wasn't already present
+func (addresses Addresses) AppendIfMissing(address sdk.AccAddress) Addresses {
+	for _, ele := range addresses {
+		if ele.Equals(address) {
+			return addresses
+		}
+	}
+	return append(addresses, address)
+}

--- a/x/docs/internal/types/document_receipt.go
+++ b/x/docs/internal/types/document_receipt.go
@@ -4,7 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// DocumentReceipt contains the generic information about the proof that a shared document (identified by the Uuid field)
+// DocumentReceipt contains the generic information about the proof that a shared document (identified by the DocumentUuid field)
 // has been read by the recipient.
 // It contains information about the sender of the receipt's proof, the recipient,
 // the original shared Document transaction's hash, a uuid that identifies which document has been received and
@@ -13,11 +13,11 @@ import (
 // transaction hash need to be referred to an existing transaction on chain and the uuid associated with document
 // has to be non-empty and unique.
 type DocumentReceipt struct {
-	Sender    sdk.AccAddress `json:"sender"`
-	Recipient sdk.AccAddress `json:"recipient"`
-	TxHash    string         `json:"tx_hash"`
-	Uuid      string         `json:"uuid"`
-	Proof     string         `json:"proof"`
+	Sender       sdk.AccAddress `json:"sender"`
+	Recipient    sdk.AccAddress `json:"recipient"`
+	TxHash       string         `json:"tx_hash"`
+	DocumentUuid string         `json:"document_uuid"`
+	Proof        string         `json:"proof"`
 }
 
 func (receipt DocumentReceipt) Equals(rec DocumentReceipt) bool {
@@ -30,7 +30,7 @@ func (receipt DocumentReceipt) Equals(rec DocumentReceipt) bool {
 	if receipt.TxHash != rec.TxHash {
 		return false
 	}
-	if receipt.Uuid != rec.Uuid {
+	if receipt.DocumentUuid != rec.DocumentUuid {
 		return false
 	}
 	if receipt.Proof != rec.Proof {
@@ -48,4 +48,14 @@ func (receipts DocumentReceipts) AppendReceiptIfMissing(receipt DocumentReceipt)
 		}
 	}
 	return append(receipts, receipt)
+}
+
+func (receipts DocumentReceipts) FindByDocumentId(docId string) DocumentReceipts {
+	var foundReceipts DocumentReceipts
+	for _, ele := range receipts {
+		if ele.DocumentUuid == docId {
+			foundReceipts = append(foundReceipts, ele)
+		}
+	}
+	return foundReceipts
 }

--- a/x/docs/internal/types/keys.go
+++ b/x/docs/internal/types/keys.go
@@ -12,8 +12,9 @@ const (
 	QueryReceivedDocuments = "received"
 	QueryReceipts          = "receipts"
 
-	//KVStore prefix
-	SentDocumentsPrefix     = StoreKey + "sentBy:"
-	ReceivedDocumentsPrefix = StoreKey + "received:"
-	DocumentReceiptPrefix   = StoreKey + "receiptOf:"
+	SentDocumentsPrefix     = StoreKey + ":documents:sent:"
+	ReceivedDocumentsPrefix = StoreKey + ":received:received:"
+
+	SentDocumentsReceiptsPrefix     = StoreKey + ":receipts:sent:"
+	ReceivedDocumentsReceiptsPrefix = StoreKey + ":receipts:received:"
 )

--- a/x/docs/internal/types/msgs.go
+++ b/x/docs/internal/types/msgs.go
@@ -35,7 +35,7 @@ func (msg MsgShareDocument) Route() string { return ModuleName }
 func (msg MsgShareDocument) Type() string { return MsgTypeShareDocument }
 
 func validateUuid(uuid string) bool {
-	regex := regexp.MustCompile(`[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}`)
+	regex := regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
 	return regex.MatchString(uuid)
 }
 
@@ -148,7 +148,7 @@ func (msg MsgSendDocumentReceipt) ValidateBasic() sdk.Error {
 	if len(msg.TxHash) == 0 {
 		return sdk.ErrUnknownRequest("Send Document's Transaction Hash can't be empty")
 	}
-	if !validateUuid(msg.Uuid) {
+	if !validateUuid(msg.DocumentUuid) {
 		return sdk.ErrUnknownRequest("Invalid document UUID")
 	}
 	if len(msg.Proof) == 0 {

--- a/x/docs/internal/types/msgs_test.go
+++ b/x/docs/internal/types/msgs_test.go
@@ -264,11 +264,11 @@ func TestValidateChecksum_invalidChecksumLengths(t *testing.T) {
 // --- DocumentReceipt tests
 // ----------------------------------
 var msgDocumentReceipt = MsgSendDocumentReceipt{
-	Sender:    sender,
-	Recipient: recipient,
-	TxHash:    "txHash",
-	Uuid:      "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
-	Proof:     "proof",
+	Sender:       sender,
+	Recipient:    recipient,
+	TxHash:       "txHash",
+	DocumentUuid: "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
+	Proof:        "proof",
 }
 
 func TestMsgDocumentReceipt_Route(t *testing.T) {
@@ -292,11 +292,11 @@ func TestMsgDocumentReceipt_ValidateBasic_valid(t *testing.T) {
 
 func TestMsgDocumentReceipt_ValidateBasic_invalid(t *testing.T) {
 	var msgDocReceipt = MsgSendDocumentReceipt{
-		Sender:    sender,
-		Recipient: recipient,
-		TxHash:    "txHash",
-		Uuid:      "123456789",
-		Proof:     "proof",
+		Sender:       sender,
+		Recipient:    recipient,
+		TxHash:       "txHash",
+		DocumentUuid: "123456789",
+		Proof:        "proof",
 	}
 	actual := msgDocReceipt.ValidateBasic()
 

--- a/x/id/client/cli/tx.go
+++ b/x/id/client/cli/tx.go
@@ -31,7 +31,7 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 // GetCmdSetIdentity is the CLI command for sending a SetIdentity transaction
 func GetCmdSetIdentity(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "set-identity [did-document-uri]",
+		Use:   "set [did-document-uri]",
 		Short: "Associates the given did document reference to your Did",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/id/genesis.go
+++ b/x/id/genesis.go
@@ -1,26 +1,38 @@
 package id
 
 import (
+	"github.com/commercionetwork/commercionetwork/x/id/internal/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-/**
-THIS FILE IS USELESS BUT IT HELPS ME REMEMBER THIS FILE STRUCTURE IN ORDER TO USE IT IN FUTURE MODULES
-*/
-
+// GenesisState - id genesis state
 type GenesisState struct {
+	Identities []types.Identity `json:"identities"`
 }
 
+// DefaultGenesisState returns a default genesis state
 func DefaultGenesisState() GenesisState {
 	return GenesisState{}
 }
 
-func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {}
-
-func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
-	return DefaultGenesisState()
+// InitGenesis sets ids information for genesis.
+func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {
+	keeper.SetIdentities(ctx, data.Identities)
 }
 
-func ValidateGenesis(data GenesisState) error {
+// ExportGenesis returns a GenesisState for a given context and keeper.
+func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
+	identities, err := keeper.GetIdentities(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return GenesisState{
+		Identities: identities,
+	}
+}
+
+// ValidateGenesis performs basic validation of genesis data returning an
+// error for any failed validation criteria.
+func ValidateGenesis(_ GenesisState) error {
 	return nil
 }

--- a/x/id/internal/keeper/keeper.go
+++ b/x/id/internal/keeper/keeper.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"strings"
+
 	"github.com/commercionetwork/commercionetwork/x/id/internal/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -21,16 +23,54 @@ func NewKeeper(storeKey sdk.StoreKey, cdc *codec.Codec) Keeper {
 	}
 }
 
+func (keeper Keeper) getIdentiyStoreKey(owner sdk.AccAddress) []byte {
+	return []byte(types.IdentitiesStorePrefix + owner.String())
+}
+
 // SaveIdentity saves the given didDocumentUri associating it with the given owner, replacing any existent one.
 func (keeper Keeper) SaveIdentity(ctx sdk.Context, owner sdk.AccAddress, didDocumentUri string) {
 	identitiesStore := ctx.KVStore(keeper.StoreKey)
-	identitiesStore.Set([]byte(types.IdentitiesStorePrefix+owner.String()), []byte(didDocumentUri))
+	identitiesStore.Set(keeper.getIdentiyStoreKey(owner), []byte(didDocumentUri))
 }
 
 // GetIdentity returns the Did Document reference associated to a given Did.
 // If the given Did has no Did Document reference associated, returns nil.
 func (keeper Keeper) GetDidDocumentUriByDid(ctx sdk.Context, owner sdk.AccAddress) string {
 	store := ctx.KVStore(keeper.StoreKey)
-	result := store.Get([]byte(types.IdentitiesStorePrefix + owner.String()))
+	result := store.Get(keeper.getIdentiyStoreKey(owner))
 	return string(result)
+}
+
+// -------------------------
+// --- Genesis utils
+// -------------------------
+
+// GetIdentities returns the list of all identities for the given context
+func (keeper Keeper) GetIdentities(ctx sdk.Context) ([]types.Identity, error) {
+	store := ctx.KVStore(keeper.StoreKey)
+	iterator := sdk.KVStorePrefixIterator(store, []byte(types.IdentitiesStorePrefix))
+
+	var identities []types.Identity
+	for ; iterator.Valid(); iterator.Next() {
+		addressString := strings.ReplaceAll(string(iterator.Key()), types.IdentitiesStorePrefix, "")
+		address, err := sdk.AccAddressFromBech32(addressString)
+		if err != nil {
+			return nil, err
+		}
+
+		identity := types.Identity{
+			Owner:       address,
+			DidDocument: string(iterator.Value()),
+		}
+		identities = append(identities, identity)
+	}
+
+	return identities, nil
+}
+
+// SetIdentities allows to bulk save a bunch of identities inside the store
+func (keeper Keeper) SetIdentities(ctx sdk.Context, identities []types.Identity) {
+	for _, identity := range identities {
+		keeper.SaveIdentity(ctx, identity.Owner, identity.DidDocument)
+	}
 }

--- a/x/id/internal/keeper/keeper_test.go
+++ b/x/id/internal/keeper/keeper_test.go
@@ -4,39 +4,105 @@ import (
 	"testing"
 
 	"github.com/commercionetwork/commercionetwork/x/id/internal/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestKeeper_CreateIdentity(t *testing.T) {
 	identitiesStore := TestUtils.Ctx.KVStore(TestUtils.IdKeeper.StoreKey)
-	storeData := len(identitiesStore.Get([]byte(types.IdentitiesStorePrefix + TestOwnerAddress.String())))
+	storeData := len(identitiesStore.Get(TestUtils.IdKeeper.getIdentiyStoreKey(TestOwnerAddress)))
 	assert.Equal(t, 0, storeData)
 
 	TestUtils.IdKeeper.SaveIdentity(TestUtils.Ctx, TestOwnerAddress, TestDidDocumentUri)
 
-	afterOpLen := len(identitiesStore.Get([]byte(types.IdentitiesStorePrefix + TestOwnerAddress.String())))
+	afterOpLen := len(identitiesStore.Get(TestUtils.IdKeeper.getIdentiyStoreKey(TestOwnerAddress)))
 	assert.Equal(t, len(TestDidDocumentUri), afterOpLen)
 }
 
 func TestKeeper_EditIdentity(t *testing.T) {
 	store := TestUtils.Ctx.KVStore(TestUtils.IdKeeper.StoreKey)
-	store.Set([]byte(types.IdentitiesStorePrefix+TestOwnerAddress.String()), []byte(TestDidDocumentUri))
-	storeData := store.Get([]byte(types.IdentitiesStorePrefix + TestOwnerAddress.String()))
+	store.Set(TestUtils.IdKeeper.getIdentiyStoreKey(TestOwnerAddress), []byte(TestDidDocumentUri))
+	storeData := store.Get(TestUtils.IdKeeper.getIdentiyStoreKey(TestOwnerAddress))
 	assert.Equal(t, []byte(TestDidDocumentUri), storeData)
 
 	updatedIdentityRef := "ddo-reference-update"
 	TestUtils.IdKeeper.SaveIdentity(TestUtils.Ctx, TestOwnerAddress, updatedIdentityRef)
 
-	updatedLen := store.Get([]byte(types.IdentitiesStorePrefix + TestOwnerAddress.String()))
+	updatedLen := store.Get(TestUtils.IdKeeper.getIdentiyStoreKey(TestOwnerAddress))
 	assert.Equal(t, []byte(updatedIdentityRef), updatedLen)
 }
 
 func TestKeeper_GetDidDocumentUriByDid(t *testing.T) {
 	store := TestUtils.Ctx.KVStore(TestUtils.IdKeeper.StoreKey)
-	store.Set([]byte(types.IdentitiesStorePrefix+TestOwnerAddress.String()), []byte(TestDidDocumentUri))
-	storeData := store.Get([]byte(types.IdentitiesStorePrefix + TestOwnerAddress.String()))
+	store.Set(TestUtils.IdKeeper.getIdentiyStoreKey(TestOwnerAddress), []byte(TestDidDocumentUri))
+	storeData := store.Get(TestUtils.IdKeeper.getIdentiyStoreKey(TestOwnerAddress))
 	assert.Equal(t, []byte(TestDidDocumentUri), storeData)
 
 	actual := TestUtils.IdKeeper.GetDidDocumentUriByDid(TestUtils.Ctx, TestOwnerAddress)
 	assert.Equal(t, TestDidDocumentUri, actual)
+}
+
+// -------------------------
+// --- Genesis utils
+// -------------------------
+
+func TestKeeper_GetIdentities(t *testing.T) {
+	store := TestUtils.Ctx.KVStore(TestUtils.IdKeeper.StoreKey)
+	iterator := sdk.KVStorePrefixIterator(store, []byte(types.IdentitiesStorePrefix))
+	for ; iterator.Valid(); iterator.Next() {
+		store.Delete(iterator.Key())
+	}
+
+	first, err := sdk.AccAddressFromBech32("cosmos18xffcd029jn3thr0wwxah6gjdldr3kchvydkuj")
+	second, err := sdk.AccAddressFromBech32("cosmos18t0e6fevehhjv682gkxpchvmnl7z7ue4t4w0nd")
+	third, err := sdk.AccAddressFromBech32("cosmos1zt9etyl07asvf32g0d7ddjanres2qt9cr0fek6")
+	fourth, err := sdk.AccAddressFromBech32("cosmos177ap6yqt87znxmep5l7vdaac59uxyn582kv0gl")
+	fifth, err := sdk.AccAddressFromBech32("cosmos1ajv8j3e0ud2uduzdqmxfcvwm3nwdgr447yvu5m")
+	assert.Nil(t, err)
+
+	store.Set(TestUtils.IdKeeper.getIdentiyStoreKey(first), []byte("first"))
+	store.Set(TestUtils.IdKeeper.getIdentiyStoreKey(second), []byte("second"))
+	store.Set(TestUtils.IdKeeper.getIdentiyStoreKey(third), []byte("third"))
+	store.Set(TestUtils.IdKeeper.getIdentiyStoreKey(fourth), []byte("fourth"))
+	store.Set(TestUtils.IdKeeper.getIdentiyStoreKey(fifth), []byte("fifth"))
+
+	actual, err := TestUtils.IdKeeper.GetIdentities(TestUtils.Ctx)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 5, len(actual))
+	assert.Contains(t, actual, types.Identity{Owner: first, DidDocument: "first"})
+	assert.Contains(t, actual, types.Identity{Owner: second, DidDocument: "second"})
+	assert.Contains(t, actual, types.Identity{Owner: third, DidDocument: "third"})
+	assert.Contains(t, actual, types.Identity{Owner: fourth, DidDocument: "fourth"})
+	assert.Contains(t, actual, types.Identity{Owner: fifth, DidDocument: "fifth"})
+}
+
+func TestKeeper_SetIdentities(t *testing.T) {
+	store := TestUtils.Ctx.KVStore(TestUtils.IdKeeper.StoreKey)
+	iterator := sdk.KVStorePrefixIterator(store, []byte(types.IdentitiesStorePrefix))
+	for ; iterator.Valid(); iterator.Next() {
+		store.Delete(iterator.Key())
+	}
+
+	first, err := sdk.AccAddressFromBech32("cosmos18xffcd029jn3thr0wwxah6gjdldr3kchvydkuj")
+	second, err := sdk.AccAddressFromBech32("cosmos18t0e6fevehhjv682gkxpchvmnl7z7ue4t4w0nd")
+	third, err := sdk.AccAddressFromBech32("cosmos1zt9etyl07asvf32g0d7ddjanres2qt9cr0fek6")
+	fourth, err := sdk.AccAddressFromBech32("cosmos177ap6yqt87znxmep5l7vdaac59uxyn582kv0gl")
+	fifth, err := sdk.AccAddressFromBech32("cosmos1ajv8j3e0ud2uduzdqmxfcvwm3nwdgr447yvu5m")
+	assert.Nil(t, err)
+
+	identities := []types.Identity{
+		{Owner: first, DidDocument: "first"},
+		{Owner: second, DidDocument: "second"},
+		{Owner: third, DidDocument: "third"},
+		{Owner: fourth, DidDocument: "fourth"},
+		{Owner: fifth, DidDocument: "fifth"},
+	}
+	TestUtils.IdKeeper.SetIdentities(TestUtils.Ctx, identities)
+
+	assert.True(t, store.Has(TestUtils.IdKeeper.getIdentiyStoreKey(first)))
+	assert.True(t, store.Has(TestUtils.IdKeeper.getIdentiyStoreKey(second)))
+	assert.True(t, store.Has(TestUtils.IdKeeper.getIdentiyStoreKey(third)))
+	assert.True(t, store.Has(TestUtils.IdKeeper.getIdentiyStoreKey(fourth)))
+	assert.True(t, store.Has(TestUtils.IdKeeper.getIdentiyStoreKey(fifth)))
 }

--- a/x/id/internal/keeper/test_commons.go
+++ b/x/id/internal/keeper/test_commons.go
@@ -5,7 +5,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/params"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
@@ -14,11 +13,9 @@ import (
 )
 
 type testInput struct {
-	Cdc        *codec.Codec
-	Ctx        sdk.Context
-	accKeeper  auth.AccountKeeper
-	bankKeeper bank.BaseKeeper
-	IdKeeper   Keeper
+	Cdc      *codec.Codec
+	Ctx      sdk.Context
+	IdKeeper Keeper
 }
 
 //This function create an environment to test modules
@@ -45,22 +42,14 @@ func setupTestInput() testInput {
 
 	_ = ms.LoadLatestVersion()
 
-	pk := params.NewKeeper(cdc, keyParams, tkeyParams, params.DefaultCodespace)
-	ak := auth.NewAccountKeeper(cdc, authKey, pk.Subspace(auth.DefaultParamspace), auth.ProtoBaseAccount)
-	bk := bank.NewBaseKeeper(ak, pk.Subspace(bank.DefaultParamspace), bank.DefaultCodespace, map[string]bool{})
-
 	ctx := sdk.NewContext(ms, abci.Header{ChainID: "test-chain-id"}, false, log.NewNopLogger())
 
 	idk := NewKeeper(storeKey, cdc)
 
-	ak.SetParams(ctx, auth.DefaultParams())
-
 	return testInput{
-		Cdc:        cdc,
-		Ctx:        ctx,
-		accKeeper:  ak,
-		bankKeeper: bk,
-		IdKeeper:   idk,
+		Cdc:      cdc,
+		Ctx:      ctx,
+		IdKeeper: idk,
 	}
 
 }

--- a/x/id/internal/types/identity.go
+++ b/x/id/internal/types/identity.go
@@ -4,6 +4,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// Identity contains the data of an identity that can be specified inside the genesis and are
+// exported during the current state exportation.
 type Identity struct {
 	Owner       sdk.AccAddress `json:"owner"`
 	DidDocument string         `json:"did_document"`

--- a/x/id/internal/types/identity.go
+++ b/x/id/internal/types/identity.go
@@ -1,0 +1,10 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type Identity struct {
+	Owner       sdk.AccAddress `json:"owner"`
+	DidDocument string         `json:"did_document"`
+}


### PR DESCRIPTION
### Changes
* Changed the `set-identity` command to a simple `set` 
* Added the handling of the genesis data so that current state can be exported and later imported properly, allowing to keep all the set identities