### PR TITLE
CommercioDOCS improvements & Government addition

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -8,6 +8,7 @@ import (
 	"github.com/commercionetwork/commercionetwork/x/encapsulated/customgov"
 	"github.com/commercionetwork/commercionetwork/x/encapsulated/custommint"
 	"github.com/commercionetwork/commercionetwork/x/encapsulated/customstaking"
+	"github.com/commercionetwork/commercionetwork/x/government"
 	"github.com/commercionetwork/commercionetwork/x/id"
 	"github.com/commercionetwork/commercionetwork/x/memberships"
 	"github.com/cosmos/cosmos-sdk/simapp"
@@ -112,6 +113,7 @@ var (
 		id.AppModuleBasic{},
 		docs.AppModuleBasic{},
 		memberships.AppModuleBasic{},
+		government.AppModuleBasic{},
 	)
 
 	maccPerms = map[string][]string{
@@ -169,9 +171,10 @@ type CommercioNetworkApp struct {
 	nftKeeper      nft.Keeper
 
 	// Custom modules
-	commercioIdKeeper         id.Keeper
-	commercioDocsKeeper       docs.Keeper
-	commercioMembershipKeeper memberships.Keeper
+	idKeeper         id.Keeper
+	docsKeeper       docs.Keeper
+	membershipKeeper memberships.Keeper
+	governmentKeeper government.Keeper
 
 	mm *module.Manager
 }
@@ -195,9 +198,7 @@ func NewCommercioNetworkApp(logger log.Logger, db dbm.DB, traceStore io.Writer, 
 		gov.StoreKey, params.StoreKey, nft.StoreKey,
 
 		// Custom modules
-		id.StoreKey,
-		docs.StoreKey,
-		memberships.StoreKey,
+		id.StoreKey, docs.StoreKey, memberships.StoreKey, government.StoreKey,
 	)
 	tkeys := sdk.NewTransientStoreKeys(staking.TStoreKey, params.TStoreKey)
 
@@ -239,9 +240,10 @@ func NewCommercioNetworkApp(logger log.Logger, db dbm.DB, traceStore io.Writer, 
 	app.nftKeeper = nft.NewKeeper(app.cdc, app.keys[nft.StoreKey])
 
 	// Custom modules
-	app.commercioIdKeeper = id.NewKeeper(app.keys[id.StoreKey], app.cdc)
-	app.commercioDocsKeeper = docs.NewKeeper(app.keys[docs.StoreKey], app.cdc)
-	app.commercioMembershipKeeper = memberships.NewKeeper(app.cdc, app.keys[memberships.StoreKey], app.nftKeeper)
+	app.idKeeper = id.NewKeeper(app.keys[id.StoreKey], app.cdc)
+	app.governmentKeeper = government.NewKeeper(app.keys[government.StoreKey], app.cdc)
+	app.docsKeeper = docs.NewKeeper(app.keys[docs.StoreKey], app.governmentKeeper, app.cdc)
+	app.membershipKeeper = memberships.NewKeeper(app.cdc, app.keys[memberships.StoreKey], app.nftKeeper)
 
 	// register the proposal types
 	govRouter := gov.NewRouter()
@@ -277,9 +279,10 @@ func NewCommercioNetworkApp(logger log.Logger, db dbm.DB, traceStore io.Writer, 
 		crisis.NewAppModule(&app.crisisKeeper),
 
 		// Custom modules
-		id.NewAppModule(app.commercioIdKeeper),
-		docs.NewAppModule(app.commercioDocsKeeper),
-		memberships.NewAppModule(app.commercioMembershipKeeper),
+		id.NewAppModule(app.idKeeper),
+		docs.NewAppModule(app.docsKeeper),
+		memberships.NewAppModule(app.membershipKeeper),
+		government.NewAppModule(app.governmentKeeper),
 	)
 
 	// During begin block slashing happens after distr.BeginBlocker so that
@@ -298,7 +301,7 @@ func NewCommercioNetworkApp(logger log.Logger, db dbm.DB, traceStore io.Writer, 
 		nft.ModuleName,
 
 		// Custom modules
-		id.ModuleName, docs.ModuleName, memberships.ModuleName,
+		id.ModuleName, docs.ModuleName, memberships.ModuleName, government.ModuleName,
 	)
 
 	app.mm.RegisterInvariants(&app.crisisKeeper)

--- a/app/app.go
+++ b/app/app.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	appName = "Commercio.network"
-	Version = "1.0.2"
+	Version = "1.1.0"
 
 	DefaultBondDenom = "ucommercio"
 

--- a/cmd/cnd/main.go
+++ b/cmd/cnd/main.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/commercionetwork/commercionetwork/app"
-	genmintcli "github.com/commercionetwork/commercionetwork/x/genmembershipminters/client/cli"
+	gencmds "github.com/commercionetwork/commercionetwork/x/gencommands/client/cli"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/genaccounts"
 
@@ -56,7 +56,8 @@ func main() {
 	rootCmd.AddCommand(genutilcli.MigrateGenesisCmd(ctx, cdc))
 	rootCmd.AddCommand(genutilcli.ValidateGenesisCmd(ctx, cdc, app.ModuleBasics))
 	rootCmd.AddCommand(genaccscli.AddGenesisAccountCmd(ctx, cdc, app.DefaultNodeHome, app.DefaultCLIHome))
-	rootCmd.AddCommand(genmintcli.AddGenesisMembershipMinterCmd(ctx, cdc, app.DefaultNodeHome, app.DefaultCLIHome))
+	rootCmd.AddCommand(gencmds.SetGenesisGovernmentAddressCmd(ctx, cdc, app.DefaultNodeHome, app.DefaultCLIHome))
+	rootCmd.AddCommand(gencmds.AddGenesisMembershipMinterCmd(ctx, cdc, app.DefaultNodeHome, app.DefaultCLIHome))
 	rootCmd.AddCommand(genutilcli.GenTxCmd(ctx, cdc, app.ModuleBasics, staking.AppModuleBasic{},
 		genaccounts.AppModuleBasic{}, app.DefaultNodeHome, app.DefaultCLIHome))
 	rootCmd.AddCommand(client.NewCompletionCmd(rootCmd, true))

--- a/x/docs/alias.go
+++ b/x/docs/alias.go
@@ -19,9 +19,11 @@ var (
 )
 
 type (
-	Keeper                 = keeper.Keeper
-	Document               = types.Document
-	DocumentReceipt        = types.DocumentReceipt
-	MsgShareDocument       = types.MsgShareDocument
-	MsgSendDocumentReceipt = types.MsgSendDocumentReceipt
+	Keeper                              = keeper.Keeper
+	Document                            = types.Document
+	DocumentReceipt                     = types.DocumentReceipt
+	MsgShareDocument                    = types.MsgShareDocument
+	MsgSendDocumentReceipt              = types.MsgSendDocumentReceipt
+	MsgAddSupportedMetadataSchema       = types.MsgAddSupportedMetadataSchema
+	MsgAddTrustedMetadataSchemaProposer = types.MsgAddTrustedMetadataSchemaProposer
 )

--- a/x/docs/client/cli/query.go
+++ b/x/docs/client/cli/query.go
@@ -9,8 +9,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/spf13/cobra"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func GetQueryCmd(cdc *codec.Codec) *cobra.Command {
@@ -22,39 +20,23 @@ func GetQueryCmd(cdc *codec.Codec) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	cmd.AddCommand(GetCmdSentDocuments(cdc), GetCmdReceivedDocuments(cdc), GetCmdReceivedReceipts(cdc))
+	cmd.AddCommand(
+		getCmdSentDocuments(cdc),
+		getCmdReceivedDocuments(cdc),
+		getCmdSentReceipts(cdc),
+		getCmdReceivedReceipts(cdc),
+		getCmdSupportedMetadataSchemes(cdc),
+		getCmdMetadataSchemesProposers(cdc),
+	)
 
 	return cmd
 }
 
 // ----------------------------------
-// --- ShareDocument
+// --- Documents
 // ----------------------------------
 
-func GetCmdRetrieveDocument(cdc *codec.Codec) *cobra.Command {
-	return &cobra.Command{
-		Use:   "document [document-uuid]",
-		Short: "Get the document information for the given uuid value",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			checksumValue := args[0]
-
-			route := fmt.Sprintf("custom/%s/document/%s", types.QuerierRoute, checksumValue)
-			res, _, err := cliCtx.QueryWithData(route, nil)
-			if err != nil {
-				fmt.Printf("Could not get document from checksum %s: \n %s", checksumValue, err)
-				return nil
-			}
-
-			fmt.Println(string(res))
-
-			return nil
-		},
-	}
-}
-
-func GetCmdSentDocuments(cdc *codec.Codec) *cobra.Command {
+func getCmdSentDocuments(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "sent-documents [user-address]",
 		Short: "Get all documents sent by user",
@@ -75,7 +57,7 @@ func GetCmdSentDocuments(cdc *codec.Codec) *cobra.Command {
 	}
 }
 
-func GetCmdReceivedDocuments(cdc *codec.Codec) *cobra.Command {
+func getCmdReceivedDocuments(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "received-documents [user-address]",
 		Short: "Get all documents received by user",
@@ -96,23 +78,47 @@ func GetCmdReceivedDocuments(cdc *codec.Codec) *cobra.Command {
 	}
 }
 
-func GetCmdSharedDocumentsWithUser(cdc *codec.Codec) *cobra.Command {
+// ----------------------------------
+// --- Document metadata schemes
+// ----------------------------------
+
+func getCmdSupportedMetadataSchemes(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "shared-with [user-address]",
-		Short: "Get all documents shared with given address",
-		Args:  cobra.ExactArgs(1),
+		Use:   "metadata-schemes",
+		Short: "Get all the supported metadata schemes",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
-			address, err := sdk.AccAddressFromBech32(args[0])
+			route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QuerySupportedMetadataSchemes)
+			res, _, err := cliCtx.QueryWithData(route, nil)
 			if err != nil {
-				fmt.Printf("The given address doesn't exist or it's wrong")
+				fmt.Printf("Could not get supported metadata schemes: \n %s", err)
 			}
 
-			route := fmt.Sprintf("custom/%s/shared-with/%s", types.QuerierRoute, address)
-			res, _, err2 := cliCtx.QueryWithData(route, nil)
-			if err2 != nil {
-				fmt.Printf("Could not get any shared document with %s: \n %s", string(address), err2)
+			fmt.Println(string(res))
+
+			return nil
+		},
+	}
+}
+
+// -----------------------------------------
+// --- Document metadata schemes proposers
+// -----------------------------------------
+
+func getCmdMetadataSchemesProposers(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "metadata-schemes-proposers",
+		Short: "Get all the metadata schemes proposers",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryTrustedMetadataProposers)
+			res, _, err := cliCtx.QueryWithData(route, nil)
+			if err != nil {
+				fmt.Printf("Could not get metadata proposers: \n %s", err)
 			}
 
 			fmt.Println(string(res))
@@ -123,12 +129,33 @@ func GetCmdSharedDocumentsWithUser(cdc *codec.Codec) *cobra.Command {
 }
 
 // ----------------------------------
-// --- DocumentReceipt
+// --- Document receipts
 // ----------------------------------
 
-func GetCmdReceivedReceipts(cdc *codec.Codec) *cobra.Command {
+func getCmdSentReceipts(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "receipts [user-address] [[doc-uuid]]",
+		Use:   "sent-receipts [user-address]",
+		Short: "Get all the receipts sent from the specified user",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			route := fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute, types.QuerySentReceipts, args[0])
+			res, _, err2 := cliCtx.QueryWithData(route, nil)
+			if err2 != nil {
+				fmt.Printf("Could not get any sent receipt for the given user: \n %s", err2)
+			}
+
+			fmt.Printf(string(res))
+
+			return nil
+		},
+	}
+}
+
+func getCmdReceivedReceipts(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "received-receipts [user-address] [[doc-uuid]]",
 		Short: "Get the document receipt associated with given document uuid",
 		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -139,10 +166,10 @@ func GetCmdReceivedReceipts(cdc *codec.Codec) *cobra.Command {
 				uuid = args[1]
 			}
 
-			route := fmt.Sprintf("custom/%s/%s/%s/%s", types.QuerierRoute, types.QueryReceipts, addr, uuid)
+			route := fmt.Sprintf("custom/%s/%s/%s/%s", types.QuerierRoute, types.QueryReceivedReceipts, addr, uuid)
 			res, _, err2 := cliCtx.QueryWithData(route, nil)
 			if err2 != nil {
-				fmt.Printf("Could not get any receipt associated with the given user or uuid: \n %s", err2)
+				fmt.Printf("Could not get any received receipt for the given user or uuid: \n %s", err2)
 			}
 
 			fmt.Printf(string(res))

--- a/x/docs/client/cli/tx.go
+++ b/x/docs/client/cli/tx.go
@@ -62,7 +62,7 @@ func GetCmdShareDocument(cdc *codec.Codec) *cobra.Command {
 				Uuid:       args[1],
 				Metadata: types.DocumentMetadata{
 					ContentUri: args[2],
-					Schema: types.DocumentMetadataSchema{
+					Schema: &types.DocumentMetadataSchema{
 						Uri:     args[3],
 						Version: args[4],
 					},

--- a/x/docs/client/cli/tx.go
+++ b/x/docs/client/cli/tx.go
@@ -22,15 +22,14 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 	txCmd.AddCommand(
-		GetCmdShareDocument(cdc),
-		GetCmdSendDocumentReceipt(cdc),
+		getCmdShareDocument(cdc),
+		getCmdSendDocumentReceipt(cdc),
 	)
 
 	return txCmd
 }
 
-// GetCmdShareDocument is the CLI command for sending a ShareDocument transaction
-func GetCmdShareDocument(cdc *codec.Codec) *cobra.Command {
+func getCmdShareDocument(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "share [recipient] [document-uuid] [document-metadata-uri] " +
 			"[metadata-schema-uri] [metadata-schema-version] [metadata-verification-proof] " +
@@ -89,7 +88,7 @@ func GetCmdShareDocument(cdc *codec.Codec) *cobra.Command {
 	return cmd
 }
 
-func GetCmdSendDocumentReceipt(cdc *codec.Codec) *cobra.Command {
+func getCmdSendDocumentReceipt(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "send-receipt [recipient] [tx-hash] [document-uuid] [proof]",
 		Short: "Send the document's receipt with the given recipient address",

--- a/x/docs/client/rest/query.go
+++ b/x/docs/client/rest/query.go
@@ -11,27 +11,51 @@ import (
 )
 
 const (
-	addressRestParameterName = "owner"
+	addressRestParameterName = "user"
 )
 
-func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router, routerName string) {
+func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	r.HandleFunc(
-		fmt.Sprintf("/%s/sent/{%s}", routerName, addressRestParameterName),
+		fmt.Sprintf("{%s}/documents/sent", addressRestParameterName),
 		getSentDocumentsHandler(cliCtx)).
 		Methods("GET")
 
 	r.HandleFunc(
-		fmt.Sprintf("/%s/received/{%s}", routerName, addressRestParameterName),
+		fmt.Sprintf("{%s}/documents/received", addressRestParameterName),
 		getReceivedDocumentsHandler(cliCtx)).
 		Methods("GET")
+
+	r.HandleFunc(
+		fmt.Sprintf("{%s}/receipts/sent", addressRestParameterName),
+		getSentDocumentsReceiptsHandler(cliCtx)).
+		Methods("GET")
+
+	r.HandleFunc(
+		fmt.Sprintf("{%s}/receipts/received", addressRestParameterName),
+		getReceivedDocumentsReceiptsHandler(cliCtx)).
+		Methods("GET")
+
+	r.HandleFunc(
+		fmt.Sprintf("/metadataSchemes"),
+		getSupportedMetadataSchemesHandler(cliCtx)).
+		Methods("GET")
+
+	r.HandleFunc(
+		fmt.Sprintf("/metadataSchemes/proposers"),
+		getTrustedMetadataSchemesProposersHandler(cliCtx)).
+		Methods("GET")
 }
+
+// ----------------------------------
+// --- Documents
+// ----------------------------------
 
 func getSentDocumentsHandler(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		address := vars[addressRestParameterName]
 
-		route := fmt.Sprintf("custom/%s/%s/%s", types.ModuleName, types.QuerySentDocuments, address)
+		route := fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute, types.QuerySentDocuments, address)
 		res, _, err := cliCtx.QueryWithData(route, nil)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
@@ -47,7 +71,77 @@ func getReceivedDocumentsHandler(cliCtx context.CLIContext) http.HandlerFunc {
 		vars := mux.Vars(r)
 		address := vars[addressRestParameterName]
 
-		route := fmt.Sprintf("custom/%s/%s/%s", types.ModuleName, types.QueryReceivedDocuments, address)
+		route := fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute, types.QueryReceivedDocuments, address)
+		res, _, err := cliCtx.QueryWithData(route, nil)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}
+
+// ---------------------------------
+// --- Document receipts
+// ---------------------------------
+
+func getSentDocumentsReceiptsHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		address := vars[addressRestParameterName]
+
+		route := fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute, types.QuerySentReceipts, address)
+		res, _, err := cliCtx.QueryWithData(route, nil)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}
+
+func getReceivedDocumentsReceiptsHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		address := vars[addressRestParameterName]
+
+		route := fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute, types.QueryReceivedReceipts, address)
+		res, _, err := cliCtx.QueryWithData(route, nil)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}
+
+// ----------------------------------
+// --- Document metadata schemes
+// ----------------------------------
+
+func getSupportedMetadataSchemesHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QuerySupportedMetadataSchemes)
+		res, _, err := cliCtx.QueryWithData(route, nil)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}
+
+// -----------------------------------------
+// --- Document metadata schemes proposers
+// -----------------------------------------
+
+func getTrustedMetadataSchemesProposersHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryTrustedMetadataProposers)
 		res, _, err := cliCtx.QueryWithData(route, nil)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())

--- a/x/docs/client/rest/query.go
+++ b/x/docs/client/rest/query.go
@@ -16,32 +16,32 @@ const (
 
 func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	r.HandleFunc(
-		fmt.Sprintf("{%s}/documents/sent", addressRestParameterName),
+		fmt.Sprintf("docs/{%s}/sent", addressRestParameterName),
 		getSentDocumentsHandler(cliCtx)).
 		Methods("GET")
 
 	r.HandleFunc(
-		fmt.Sprintf("{%s}/documents/received", addressRestParameterName),
+		fmt.Sprintf("docs/{%s}/received", addressRestParameterName),
 		getReceivedDocumentsHandler(cliCtx)).
 		Methods("GET")
 
 	r.HandleFunc(
-		fmt.Sprintf("{%s}/receipts/sent", addressRestParameterName),
+		fmt.Sprintf("receipts/{%s}/sent", addressRestParameterName),
 		getSentDocumentsReceiptsHandler(cliCtx)).
 		Methods("GET")
 
 	r.HandleFunc(
-		fmt.Sprintf("{%s}/receipts/received", addressRestParameterName),
+		fmt.Sprintf("receipts/{%s}/received", addressRestParameterName),
 		getReceivedDocumentsReceiptsHandler(cliCtx)).
 		Methods("GET")
 
 	r.HandleFunc(
-		fmt.Sprintf("/metadataSchemes"),
+		fmt.Sprintf("docs/metadataSchemes"),
 		getSupportedMetadataSchemesHandler(cliCtx)).
 		Methods("GET")
 
 	r.HandleFunc(
-		fmt.Sprintf("/metadataSchemes/proposers"),
+		fmt.Sprintf("docs/metadataSchemes/proposers"),
 		getTrustedMetadataSchemesProposersHandler(cliCtx)).
 		Methods("GET")
 }

--- a/x/docs/client/rest/query.go
+++ b/x/docs/client/rest/query.go
@@ -16,32 +16,32 @@ const (
 
 func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	r.HandleFunc(
-		fmt.Sprintf("docs/{%s}/sent", addressRestParameterName),
+		fmt.Sprintf("/docs/{%s}/sent", addressRestParameterName),
 		getSentDocumentsHandler(cliCtx)).
 		Methods("GET")
 
 	r.HandleFunc(
-		fmt.Sprintf("docs/{%s}/received", addressRestParameterName),
+		fmt.Sprintf("/docs/{%s}/received", addressRestParameterName),
 		getReceivedDocumentsHandler(cliCtx)).
 		Methods("GET")
 
 	r.HandleFunc(
-		fmt.Sprintf("receipts/{%s}/sent", addressRestParameterName),
+		fmt.Sprintf("/receipts/{%s}/sent", addressRestParameterName),
 		getSentDocumentsReceiptsHandler(cliCtx)).
 		Methods("GET")
 
 	r.HandleFunc(
-		fmt.Sprintf("receipts/{%s}/received", addressRestParameterName),
+		fmt.Sprintf("/receipts/{%s}/received", addressRestParameterName),
 		getReceivedDocumentsReceiptsHandler(cliCtx)).
 		Methods("GET")
 
 	r.HandleFunc(
-		fmt.Sprintf("docs/metadataSchemes"),
+		fmt.Sprintf("/docs/metadataSchemes"),
 		getSupportedMetadataSchemesHandler(cliCtx)).
 		Methods("GET")
 
 	r.HandleFunc(
-		fmt.Sprintf("docs/metadataSchemes/proposers"),
+		fmt.Sprintf("/docs/metadataSchemes/proposers"),
 		getTrustedMetadataSchemesProposersHandler(cliCtx)).
 		Methods("GET")
 }

--- a/x/docs/client/rest/rest.go
+++ b/x/docs/client/rest/rest.go
@@ -6,6 +6,6 @@ import (
 )
 
 // RegisterRoutes - Central function to define routes that get registered by the main application
-func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, routerName string) {
-	registerQueryRoutes(cliCtx, r, routerName)
+func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router) {
+	registerQueryRoutes(cliCtx, r)
 }

--- a/x/docs/genesis.go
+++ b/x/docs/genesis.go
@@ -15,7 +15,9 @@ type UserDocumentsData struct {
 
 // GenesisState - docs genesis state
 type GenesisState struct {
-	UsersData []UserDocumentsData `json:"users_data"`
+	UsersData                      []UserDocumentsData   `json:"users_data"`
+	SupportedMetadataSchemes       types.MetadataSchemes `json:"supported_metadata_schemes"`
+	TrustedMetadataSchemaProposers []sdk.AccAddress      `json:"trusted_metadata_schema_proposers"`
 }
 
 // DefaultGenesisState returns a default genesis state
@@ -28,6 +30,12 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {
 	for _, data := range data.UsersData {
 		keeper.SetUserDocuments(ctx, data.User, data.SentDocuments, data.ReceivedDocuments)
 		keeper.SetUserReceipts(ctx, data.User, data.SentReceipts, data.ReceivedReceipts)
+	}
+	for _, schema := range data.SupportedMetadataSchemes {
+		keeper.AddSupportedMetadataScheme(ctx, schema)
+	}
+	for _, proposer := range data.TrustedMetadataSchemaProposers {
+		keeper.AddTrustedSchemaProposer(ctx, proposer)
 	}
 }
 
@@ -51,7 +59,9 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
 	}
 
 	return GenesisState{
-		UsersData: usersData,
+		UsersData:                      usersData,
+		SupportedMetadataSchemes:       keeper.GetSupportedMetadataSchemes(ctx),
+		TrustedMetadataSchemaProposers: keeper.GetTrustedSchemaProposers(ctx),
 	}
 }
 

--- a/x/docs/handler.go
+++ b/x/docs/handler.go
@@ -56,7 +56,7 @@ func handleMsgAddSupportedMetadataSchema(ctx sdk.Context, keeper Keeper, msg Msg
 	// Make sure the signer is valid
 	if !keeper.IsTrustedSchemaProposer(ctx, msg.Signer) {
 		errMsg := fmt.Sprintf("Signer is not a trusted one: %s", msg.Signer.String())
-		return sdk.ErrUnknownRequest(errMsg).Result()
+		return sdk.ErrInvalidAddress(errMsg).Result()
 	}
 
 	// Add the schema
@@ -70,7 +70,7 @@ func handleMsgAddTrustedMetadataSchemaProposer(ctx sdk.Context, keeper Keeper, m
 	governmentAddr := keeper.GovernmentKeeper.GetGovernmentAddress(ctx)
 	if !msg.Signer.Equals(governmentAddr) {
 		errMsg := fmt.Sprintf("Only the government can add a trusted metadata schema proposer")
-		return sdk.ErrUnknownRequest(errMsg).Result()
+		return sdk.ErrInvalidAddress(errMsg).Result()
 	}
 
 	// Add the trusted schema proposer

--- a/x/docs/handler_test.go
+++ b/x/docs/handler_test.go
@@ -6,28 +6,168 @@ import (
 	"testing"
 
 	"github.com/commercionetwork/commercionetwork/x/docs/internal/keeper"
+	"github.com/commercionetwork/commercionetwork/x/docs/internal/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var msgShareDocument = MsgShareDocument(keeper.TestingDocument)
-var msgDocumentReceipt = MsgSendDocumentReceipt(keeper.TestingDocumentReceipt)
 
 var testUtils = keeper.TestUtils
 var handler = NewHandler(testUtils.DocsKeeper)
 
-func TestValidMsg_ShareDoc(t *testing.T) {
+// -----------------------------
+// --- handleMsgShareDocument
+// -----------------------------
+
+func Test_handleMsgShareDocument_CustomMetadataSpecs(t *testing.T) {
+	msgShareDocument := MsgShareDocument(keeper.TestingDocument)
+
 	res := handler(testUtils.Ctx, msgShareDocument)
 	require.True(t, res.IsOK())
 }
 
-func TestValidMsg_DocReceipt(t *testing.T) {
-	res := handler(testUtils.Ctx, msgDocumentReceipt)
-	require.True(t, res.IsOK())
+func Test_handleMsgShareDocument_MetadataSchemeType_Supported(t *testing.T) {
+	msgShareDocument := MsgShareDocument{
+		Sender:    keeper.TestingDocument.Sender,
+		Recipient: keeper.TestingDocument.Recipient,
+		Uuid:      keeper.TestingDocument.Uuid,
+		Metadata: types.DocumentMetadata{
+			ContentUri: keeper.TestingDocument.Metadata.ContentUri,
+			SchemaType: "metadata-schema",
+			Proof:      keeper.TestingDocument.Metadata.Proof,
+		},
+		ContentUri: keeper.TestingDocument.ContentUri,
+		Checksum:   keeper.TestingDocument.Checksum,
+	}
+	supportedSchema := types.MetadataSchema{
+		Type:      "metadata-schema",
+		SchemaUri: "https://example.com/schema",
+		Version:   "1.0.0",
+	}
+	testUtils.DocsKeeper.AddSupportedMetadataScheme(testUtils.Ctx, supportedSchema)
+
+	res := handler(testUtils.Ctx, msgShareDocument)
+	assert.True(t, res.IsOK())
 }
 
-func TestInvalidMsg(t *testing.T) {
+func Test_handleMsgShareDocument_MetadataSchemeType_NotSupported(t *testing.T) {
+	msgShareDocument := MsgShareDocument{
+		Sender:    keeper.TestingDocument.Sender,
+		Recipient: keeper.TestingDocument.Recipient,
+		Uuid:      keeper.TestingDocument.Uuid,
+		Metadata: types.DocumentMetadata{
+			ContentUri: keeper.TestingDocument.Metadata.ContentUri,
+			SchemaType: "non-existent-schema-type",
+			Proof:      keeper.TestingDocument.Metadata.Proof,
+		},
+		ContentUri: keeper.TestingDocument.ContentUri,
+		Checksum:   keeper.TestingDocument.Checksum,
+	}
+
+	res := handler(testUtils.Ctx, msgShareDocument)
+	assert.False(t, res.IsOK())
+	assert.Equal(t, sdk.CodeUnknownRequest, res.Code)
+}
+
+// -----------------------------------
+// --- handleMsgSendDocumentReceipt
+// -----------------------------------
+
+func Test_handleMsgSendDocumentReceipt(t *testing.T) {
+	msgSendDocumentReceipt := MsgSendDocumentReceipt(keeper.TestingDocumentReceipt)
+
+	res := handler(testUtils.Ctx, msgSendDocumentReceipt)
+	assert.True(t, res.IsOK())
+}
+
+// -------------------------------------------
+// --- handleMsgAddSupportedMetadataSchema
+// -------------------------------------------
+
+func Test_handleMsgAddSupportedMetadataSchema_NotTrustedSigner(t *testing.T) {
+	store := testUtils.Ctx.KVStore(testUtils.DocsKeeper.StoreKey)
+	store.Delete([]byte(types.MetadataSchemaProposersStoreKey))
+
+	msgAddSupportedMetadataSchema := MsgAddSupportedMetadataSchema{
+		Signer: keeper.TestingSender,
+		Schema: types.MetadataSchema{
+			Type:      "schema-type",
+			SchemaUri: "https://example.com/schema",
+			Version:   "1.0.0",
+		},
+	}
+	res := handler(testUtils.Ctx, msgAddSupportedMetadataSchema)
+	assert.False(t, res.IsOK())
+	assert.Equal(t, sdk.CodeInvalidAddress, res.Code)
+}
+
+func Test_handleMsgAddSupportedMetadataSchema_TrustedSigner(t *testing.T) {
+	signers := []sdk.AccAddress{keeper.TestingSender}
+
+	store := testUtils.Ctx.KVStore(testUtils.DocsKeeper.StoreKey)
+	store.Set([]byte(types.MetadataSchemaProposersStoreKey), testUtils.Cdc.MustMarshalBinaryBare(&signers))
+
+	msgAddSupportedMetadataSchema := MsgAddSupportedMetadataSchema{
+		Signer: keeper.TestingSender,
+		Schema: types.MetadataSchema{
+			Type:      "schema-type",
+			SchemaUri: "https://example.com/schema",
+			Version:   "1.0.0",
+		},
+	}
+	res := handler(testUtils.Ctx, msgAddSupportedMetadataSchema)
+	assert.True(t, res.IsOK())
+}
+
+// ------------------------------------------------
+// --- handleMsgAddTrustedMetadataSchemaProposer
+// ------------------------------------------------
+
+func Test_handleMsgAddTrustedMetadataSchemaProposer_MissingGovernment(t *testing.T) {
+	store := testUtils.Ctx.KVStore(testUtils.DocsKeeper.GovernmentKeeper.StoreKey)
+	iterator := store.Iterator(nil, nil)
+	for ; iterator.Valid(); iterator.Next() {
+		store.Delete(iterator.Key())
+	}
+
+	msgAddTrustedMetadataSchemaProposer := types.MsgAddTrustedMetadataSchemaProposer{
+		Proposer: keeper.TestingSender,
+		Signer:   keeper.TestingRecipient,
+	}
+	res := handler(testUtils.Ctx, msgAddTrustedMetadataSchemaProposer)
+	assert.False(t, res.IsOK())
+	assert.Equal(t, sdk.CodeInvalidAddress, res.Code)
+}
+
+func Test_handleMsgAddTrustedMetadataSchemaProposer_IncorrectSigner(t *testing.T) {
+	testUtils.DocsKeeper.GovernmentKeeper.SetGovernmentAddress(testUtils.Ctx, keeper.TestingRecipient)
+
+	msgAddTrustedMetadataSchemaProposer := types.MsgAddTrustedMetadataSchemaProposer{
+		Proposer: keeper.TestingSender,
+		Signer:   keeper.TestingSender,
+	}
+	res := handler(testUtils.Ctx, msgAddTrustedMetadataSchemaProposer)
+	assert.False(t, res.IsOK())
+	assert.Equal(t, sdk.CodeInvalidAddress, res.Code)
+}
+
+func Test_handleMsgAddTrustedMetadataSchemaProposer_CorrectSigner(t *testing.T) {
+	testUtils.DocsKeeper.GovernmentKeeper.SetGovernmentAddress(testUtils.Ctx, keeper.TestingRecipient)
+
+	msgAddTrustedMetadataSchemaProposer := types.MsgAddTrustedMetadataSchemaProposer{
+		Proposer: keeper.TestingSender,
+		Signer:   keeper.TestingRecipient,
+	}
+	res := handler(testUtils.Ctx, msgAddTrustedMetadataSchemaProposer)
+	assert.True(t, res.IsOK())
+}
+
+// -------------------
+// --- Default case
+// -------------------
+
+func Test_invalidMsg(t *testing.T) {
 	res := handler(testUtils.Ctx, sdk.NewTestMsg())
-	require.False(t, res.IsOK())
-	require.True(t, strings.Contains(res.Log, fmt.Sprintf("Unrecognized %s message type", ModuleName)))
+	assert.False(t, res.IsOK())
+	assert.True(t, strings.Contains(res.Log, fmt.Sprintf("Unrecognized %s message type", ModuleName)))
 }

--- a/x/docs/internal/keeper/keeper.go
+++ b/x/docs/internal/keeper/keeper.go
@@ -233,7 +233,7 @@ func (keeper Keeper) GetUserReceivedReceiptsForDocument(ctx sdk.Context, recipie
 // GetUserSentDocuments returns a list of all documents sent by user
 func (keeper Keeper) GetUserSentReceipts(ctx sdk.Context, user sdk.AccAddress) types.DocumentReceipts {
 	store := ctx.KVStore(keeper.StoreKey)
-	sentDocs := store.Get([]byte(types.ReceivedDocumentsReceiptsPrefix + user.String()))
+	sentDocs := store.Get(keeper.getSentReceiptsStoreKey(user))
 
 	var sentReceipts types.DocumentReceipts
 	keeper.cdc.MustUnmarshalBinaryBare(sentDocs, &sentReceipts)

--- a/x/docs/internal/keeper/querier.go
+++ b/x/docs/internal/keeper/querier.go
@@ -114,6 +114,10 @@ func queryGetSentDocsReceipts(ctx sdk.Context, path []string, keeper Keeper) ([]
 	}
 
 	receipts := keeper.GetUserSentReceipts(ctx, address)
+	if receipts == nil {
+		receipts = make([]types.DocumentReceipt, 0)
+	}
+
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, &receipts)
 
 	if err != nil {

--- a/x/docs/internal/keeper/querier.go
+++ b/x/docs/internal/keeper/querier.go
@@ -21,7 +21,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 		case types.QueryReceivedReceipts:
 			return queryGetReceivedDocsReceipts(ctx, path[1:], keeper)
 		case types.QuerySentReceipts:
-			return querySentReceipts(ctx, path[1:], keeper)
+			return queryGetSentDocsReceipts(ctx, path[1:], keeper)
 		case types.QuerySupportedMetadataSchemes:
 			return querySupportedMetadataSchemes(ctx, path[1:], keeper)
 		case types.QueryTrustedMetadataProposers:
@@ -88,11 +88,12 @@ func queryGetReceivedDocsReceipts(ctx sdk.Context, path []string, keeper Keeper)
 	//If user wants all his receipts
 	if uuid == "" {
 		receipts = keeper.GetUserReceivedReceipts(ctx, address)
-		if receipts == nil {
-			receipts = make([]types.DocumentReceipt, 0)
-		}
 	} else {
 		receipts = keeper.GetUserReceivedReceiptsForDocument(ctx, address, uuid)
+	}
+
+	if receipts == nil {
+		receipts = make([]types.DocumentReceipt, 0)
 	}
 
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, &receipts)
@@ -104,7 +105,7 @@ func queryGetReceivedDocsReceipts(ctx sdk.Context, path []string, keeper Keeper)
 	return bz, nil
 }
 
-func querySentReceipts(ctx sdk.Context, path []string, keeper Keeper) ([]byte, sdk.Error) {
+func queryGetSentDocsReceipts(ctx sdk.Context, path []string, keeper Keeper) ([]byte, sdk.Error) {
 	addr := path[0]
 	address, err := sdk.AccAddressFromBech32(addr)
 
@@ -128,6 +129,9 @@ func querySentReceipts(ctx sdk.Context, path []string, keeper Keeper) ([]byte, s
 
 func querySupportedMetadataSchemes(ctx sdk.Context, _ []string, keeper Keeper) ([]byte, sdk.Error) {
 	schemes := keeper.GetSupportedMetadataSchemes(ctx)
+	if schemes == nil {
+		schemes = make([]types.MetadataSchema, 0)
+	}
 
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, &schemes)
 
@@ -144,6 +148,9 @@ func querySupportedMetadataSchemes(ctx sdk.Context, _ []string, keeper Keeper) (
 
 func queryTrustedMetadataProposers(ctx sdk.Context, _ []string, keeper Keeper) ([]byte, sdk.Error) {
 	proposers := keeper.GetTrustedSchemaProposers(ctx)
+	if proposers == nil {
+		proposers = make([]sdk.AccAddress, 0)
+	}
 
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, &proposers)
 

--- a/x/docs/internal/keeper/querier_test.go
+++ b/x/docs/internal/keeper/querier_test.go
@@ -147,6 +147,38 @@ func Test_queryGetReceivedDocsReceipts_WithDocUuid(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func Test_queryGetSentDocsReceipts_EmptyList(t *testing.T) {
+	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
+	store.Delete(TestUtils.DocsKeeper.getSentReceiptsStoreKey(TestingDocumentReceipt.Sender))
+
+	path := []string{types.QuerySentReceipts, TestingDocumentReceipt.Sender.String()}
+
+	var actual types.DocumentReceipts
+	actualBz, _ := querier(TestUtils.Ctx, path, request)
+	TestUtils.Cdc.MustUnmarshalJSON(actualBz, &actual)
+
+	assert.Equal(t, "[]", string(actualBz))
+	assert.Empty(t, actual)
+}
+
+func Test_queryGetSentDocsReceipts_ExistingList(t *testing.T) {
+	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
+
+	var stored = types.DocumentReceipts{TestingDocumentReceipt}
+	store.Set(
+		TestUtils.DocsKeeper.getSentReceiptsStoreKey(TestingDocumentReceipt.Sender),
+		TestUtils.Cdc.MustMarshalBinaryBare(&stored),
+	)
+
+	path := []string{types.QuerySentReceipts, TestingDocumentReceipt.Sender.String()}
+
+	var actual types.DocumentReceipts
+	actualBz, _ := querier(TestUtils.Ctx, path, request)
+	TestUtils.Cdc.MustUnmarshalJSON(actualBz, &actual)
+
+	assert.Equal(t, stored, actual)
+}
+
 // ----------------------------------
 // --- Document metadata schemes
 // ----------------------------------

--- a/x/docs/internal/keeper/querier_test.go
+++ b/x/docs/internal/keeper/querier_test.go
@@ -12,6 +12,10 @@ var querier = NewQuerier(TestUtils.DocsKeeper)
 var request abci.RequestQuery
 var documents = types.Documents{TestingDocument}
 
+// ----------------------------------
+// --- Documents
+// ----------------------------------
+
 func Test_queryGetReceivedDocuments(t *testing.T) {
 	// Setup the store
 	metadataStore := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
@@ -21,7 +25,7 @@ func Test_queryGetReceivedDocuments(t *testing.T) {
 	)
 
 	// Compose the path
-	path := []string{"received", TestingDocument.Recipient.String()}
+	path := []string{types.QueryReceivedDocuments, TestingDocument.Recipient.String()}
 
 	// Get the returned documents
 	var actual types.Documents
@@ -40,7 +44,7 @@ func Test_queryGetSentDocuments(t *testing.T) {
 	)
 
 	// Compose the path
-	path := []string{"sent", TestingDocument.Sender.String()}
+	path := []string{types.QuerySentDocuments, TestingDocument.Sender.String()}
 
 	// Get the returned documents
 	var actual types.Documents
@@ -50,11 +54,11 @@ func Test_queryGetSentDocuments(t *testing.T) {
 	assert.Equal(t, documents, actual)
 }
 
-// ----------------------------------
-// --- DocumentReceipt
-// ----------------------------------
+// ---------------------------------
+// --- Document receipts
+// ---------------------------------
 
-func Test_GetUserReceivedReceipts(t *testing.T) {
+func Test_queryGetReceivedDocsReceipts(t *testing.T) {
 	// Setup the store
 	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
 	store.Delete(TestUtils.DocsKeeper.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient))
@@ -66,7 +70,7 @@ func Test_GetUserReceivedReceipts(t *testing.T) {
 	)
 
 	// Compose the path
-	path := []string{"receipts", TestingDocumentReceipt.Recipient.String(), ""}
+	path := []string{types.QueryReceivedReceipts, TestingDocumentReceipt.Recipient.String(), ""}
 
 	// Get the returned receipts
 	var actual types.DocumentReceipts
@@ -76,7 +80,7 @@ func Test_GetUserReceivedReceipts(t *testing.T) {
 	assert.Equal(t, stored, actual)
 }
 
-func Test_GetUserReceivedReceiptsForDocument(t *testing.T) {
+func Test_queryGetReceivedDocsReceipts_WithDocUuid(t *testing.T) {
 	// Setup the store
 	store := TestUtils.Ctx.KVStore(TestUtils.DocsKeeper.StoreKey)
 	store.Delete(TestUtils.DocsKeeper.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient))
@@ -88,7 +92,7 @@ func Test_GetUserReceivedReceiptsForDocument(t *testing.T) {
 	)
 
 	// Compose the path
-	path := []string{"receipts", TestingDocumentReceipt.Recipient.String(), TestingDocumentReceipt.DocumentUuid}
+	path := []string{types.QueryReceivedReceipts, TestingDocumentReceipt.Recipient.String(), TestingDocumentReceipt.DocumentUuid}
 
 	// Get the returned receipts
 	var actual types.DocumentReceipts

--- a/x/docs/internal/types/accounts.go
+++ b/x/docs/internal/types/accounts.go
@@ -8,13 +8,21 @@ import (
 // enables custom operations
 type Addresses []sdk.AccAddress
 
+func (addresses Addresses) Contains(address sdk.Address) bool {
+	for _, ele := range addresses {
+		if ele.Equals(address) {
+			return true
+		}
+	}
+	return false
+}
+
 // AppendIfMissing returns a new Addresses instance containing the given
 // address if it wasn't already present
 func (addresses Addresses) AppendIfMissing(address sdk.AccAddress) Addresses {
-	for _, ele := range addresses {
-		if ele.Equals(address) {
-			return addresses
-		}
+	if addresses.Contains(address) {
+		return addresses
+	} else {
+		return append(addresses, address)
 	}
-	return append(addresses, address)
 }

--- a/x/docs/internal/types/codec.go
+++ b/x/docs/internal/types/codec.go
@@ -4,16 +4,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 )
 
-/**
- * Any interface you create and any struct that implements an interface needs to be
- * declared in the RegisterCodec function.
- * In this module the Msg implementations (SetIdentity) need to be registered,
- * but your Identity query return type does not.
- */
-
 // RegisterCodec registers concrete types on wire codec
 func RegisterCodec(cdc *codec.Codec) {
-	cdc.RegisterConcrete(MsgShareDocument{}, "commercio/ShareDocument", nil)
+	cdc.RegisterConcrete(MsgShareDocument{}, "commercio/MsgShareDocument", nil)
+	cdc.RegisterConcrete(MsgSendDocumentReceipt{}, "commercio/MsgSendDocumentReceipt", nil)
 }
 
 var ModuleCdc *codec.Codec

--- a/x/docs/internal/types/codec.go
+++ b/x/docs/internal/types/codec.go
@@ -8,6 +8,7 @@ import (
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgShareDocument{}, "commercio/MsgShareDocument", nil)
 	cdc.RegisterConcrete(MsgSendDocumentReceipt{}, "commercio/MsgSendDocumentReceipt", nil)
+	cdc.RegisterConcrete(MsgAddSupportedMetadataSchema{}, "commercio/MsgAddSupportedMetadataSchema", nil)
 }
 
 var ModuleCdc *codec.Codec

--- a/x/docs/internal/types/document.go
+++ b/x/docs/internal/types/document.go
@@ -24,10 +24,18 @@ type DocumentMetadata struct {
 	Proof      string                  `json:"proof"`
 }
 
-func (docMeta DocumentMetadata) Equals(docMeta2 DocumentMetadata) bool {
-	return docMeta.ContentUri == docMeta2.ContentUri &&
-		docMeta.Proof == docMeta2.Proof &&
-		docMeta.Schema.Equals(*docMeta2.Schema)
+func (docMeta DocumentMetadata) Equals(other DocumentMetadata) bool {
+	if docMeta.Schema == nil && other.Schema == nil {
+		return true
+	}
+
+	if docMeta.Schema == nil || other.Schema == nil {
+		return false
+	}
+
+	return docMeta.ContentUri == other.ContentUri &&
+		docMeta.Proof == other.Proof &&
+		docMeta.Schema.Equals(*other.Schema)
 }
 
 // DocumentChecksum represents the information related to the checksum of a document, if any

--- a/x/docs/internal/types/document.go
+++ b/x/docs/internal/types/document.go
@@ -18,15 +18,16 @@ func (metaSchema DocumentMetadataSchema) Equals(metSchema2 DocumentMetadataSchem
 
 // DocumentMetadata represents the information about the metadata associated to a document
 type DocumentMetadata struct {
-	ContentUri string                 `json:"content_uri"`
-	Schema     DocumentMetadataSchema `json:"schema"`
-	Proof      string                 `json:"proof"`
+	ContentUri string                  `json:"content_uri"`
+	SchemaType string                  `json:"schema_type"` // Optional - Either this or schema must be defined
+	Schema     *DocumentMetadataSchema `json:"schema"`      // Optional - Either this or schema_type must be defined
+	Proof      string                  `json:"proof"`
 }
 
 func (docMeta DocumentMetadata) Equals(docMeta2 DocumentMetadata) bool {
 	return docMeta.ContentUri == docMeta2.ContentUri &&
 		docMeta.Proof == docMeta2.Proof &&
-		docMeta.Schema.Equals(docMeta2.Schema)
+		docMeta.Schema.Equals(*docMeta2.Schema)
 }
 
 // DocumentChecksum represents the information related to the checksum of a document, if any

--- a/x/docs/internal/types/keys.go
+++ b/x/docs/internal/types/keys.go
@@ -5,12 +5,15 @@ const (
 	StoreKey     = ModuleName
 	QuerierRoute = ModuleName
 
-	MsgTypeShareDocument       = "shareDocument"
-	MsgTypeSendDocumentReceipt = "documentReceipt"
+	MsgTypeShareDocument              = "shareDocument"
+	MsgTypeSendDocumentReceipt        = "sendDocumentReceipt"
+	MsgTypeAddSupportedMetadataSchema = "addSupportedMetadataSchema"
 
 	QuerySentDocuments     = "sent"
 	QueryReceivedDocuments = "received"
 	QueryReceipts          = "receipts"
+
+	SupportedMetadataStoreKey = StoreKey + "supportedMetadata"
 
 	SentDocumentsPrefix     = StoreKey + ":documents:sent:"
 	ReceivedDocumentsPrefix = StoreKey + ":received:received:"

--- a/x/docs/internal/types/keys.go
+++ b/x/docs/internal/types/keys.go
@@ -5,19 +5,24 @@ const (
 	StoreKey     = ModuleName
 	QuerierRoute = ModuleName
 
-	MsgTypeShareDocument              = "shareDocument"
-	MsgTypeSendDocumentReceipt        = "sendDocumentReceipt"
-	MsgTypeAddSupportedMetadataSchema = "addSupportedMetadataSchema"
-
-	QuerySentDocuments     = "sent"
-	QueryReceivedDocuments = "received"
-	QueryReceipts          = "receipts"
-
-	SupportedMetadataStoreKey = StoreKey + "supportedMetadata"
+	SupportedMetadataSchemesStoreKey = StoreKey + "supportedMetadata"
+	MetadataSchemaProposersStoreKey  = StoreKey + "metadataSchemaProposers"
 
 	SentDocumentsPrefix     = StoreKey + ":documents:sent:"
 	ReceivedDocumentsPrefix = StoreKey + ":received:received:"
 
 	SentDocumentsReceiptsPrefix     = StoreKey + ":receipts:sent:"
 	ReceivedDocumentsReceiptsPrefix = StoreKey + ":receipts:received:"
+
+	MsgTypeShareDocument                    = "shareDocument"
+	MsgTypeSendDocumentReceipt              = "sendDocumentReceipt"
+	MsgTypeAddSupportedMetadataSchema       = "addSupportedMetadataSchema"
+	MsgTypeAddTrustedMetadataSchemaProposer = "addTrustedMetadataSchemaProposer"
+
+	QuerySentDocuments            = "sent"
+	QueryReceivedDocuments        = "received"
+	QueryReceivedReceipts         = "receivedReceipts"
+	QuerySentReceipts             = "sentReceipts"
+	QuerySupportedMetadataSchemes = "supportedMetadataSchemes"
+	QueryTrustedMetadataProposers = "trustedMetadataProposers"
 )

--- a/x/docs/internal/types/metadata.go
+++ b/x/docs/internal/types/metadata.go
@@ -2,18 +2,23 @@ package types
 
 import "errors"
 
+// MetadataSchema contains the information about an
+// officially supported document metadata schema
 type MetadataSchema struct {
 	Type      string `json:"type"`
 	SchemaUri string `json:"schema_uri"`
 	Version   string `json:"version"`
 }
 
+// Equals returns true iff other contains the same data as this metadata schema
 func (m MetadataSchema) Equals(other MetadataSchema) bool {
 	return m.Type == other.Type &&
 		m.SchemaUri == other.SchemaUri &&
 		m.Version == other.Version
 }
 
+// Validate allows to validate the content of the schema, returning
+// an error if something is not valid
 func (m MetadataSchema) Validate() error {
 	if len(m.Type) == 0 {
 		return errors.New("type cannot be empty")
@@ -28,8 +33,10 @@ func (m MetadataSchema) Validate() error {
 	return nil
 }
 
+// MetadataSchemes represents a list of MetadataSchema
 type MetadataSchemes []MetadataSchema
 
+// Contains returns true iff the specified metadata is present inside this list
 func (metadataSchemes MetadataSchemes) Contains(metadata MetadataSchema) bool {
 	for _, m := range metadataSchemes {
 		if m.Equals(metadata) {
@@ -39,6 +46,8 @@ func (metadataSchemes MetadataSchemes) Contains(metadata MetadataSchema) bool {
 	return false
 }
 
+// IsTypeSupported allows to tell if there is one metadata
+// scheme having the given type inside this list
 func (metadataSchemes MetadataSchemes) IsTypeSupported(metadataType string) bool {
 	for _, m := range metadataSchemes {
 		if m.Type == metadataType {
@@ -48,10 +57,11 @@ func (metadataSchemes MetadataSchemes) IsTypeSupported(metadataType string) bool
 	return false
 }
 
-func (metadataSchemes MetadataSchemes) AppendIfMissing(metadata MetadataSchema) MetadataSchemes {
-	if metadataSchemes.Contains(metadata) {
+// AppendIfMissing allows to add to this list of schemes the given schema, if it isn't already present
+func (metadataSchemes MetadataSchemes) AppendIfMissing(schema MetadataSchema) MetadataSchemes {
+	if metadataSchemes.Contains(schema) {
 		return metadataSchemes
 	} else {
-		return append(metadataSchemes, metadata)
+		return append(metadataSchemes, schema)
 	}
 }

--- a/x/docs/internal/types/metadata.go
+++ b/x/docs/internal/types/metadata.go
@@ -1,0 +1,57 @@
+package types
+
+import "errors"
+
+type MetadataSchema struct {
+	Type      string `json:"type"`
+	SchemaUri string `json:"schema_uri"`
+	Version   string `json:"version"`
+}
+
+func (m MetadataSchema) Equals(other MetadataSchema) bool {
+	return m.Type == other.Type &&
+		m.SchemaUri == other.SchemaUri &&
+		m.Version == other.Version
+}
+
+func (m MetadataSchema) Validate() error {
+	if len(m.Type) == 0 {
+		return errors.New("type cannot be empty")
+	}
+	if len(m.SchemaUri) == 0 {
+		return errors.New("uri cannot be empty")
+	}
+	if len(m.Version) == 0 {
+		return errors.New("version cannot be empty")
+	}
+
+	return nil
+}
+
+type MetadataSchemes []MetadataSchema
+
+func (metadataSchemes MetadataSchemes) Contains(metadata MetadataSchema) bool {
+	for _, m := range metadataSchemes {
+		if m.Equals(metadata) {
+			return true
+		}
+	}
+	return false
+}
+
+func (metadataSchemes MetadataSchemes) IsTypeSupported(metadataType string) bool {
+	for _, m := range metadataSchemes {
+		if m.Type == metadataType {
+			return true
+		}
+	}
+	return false
+}
+
+func (metadataSchemes MetadataSchemes) AppendIfMissing(metadata MetadataSchema) MetadataSchemes {
+	if metadataSchemes.Contains(metadata) {
+		return metadataSchemes
+	} else {
+		return append(metadataSchemes, metadata)
+	}
+}

--- a/x/docs/internal/types/msgs.go
+++ b/x/docs/internal/types/msgs.go
@@ -177,9 +177,9 @@ func (msg MsgSendDocumentReceipt) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Sender}
 }
 
-// ----------------------------------
+// ------------------------------------
 // --- MsgAddSupportedMetadataSchema
-// ----------------------------------
+// ------------------------------------
 
 type MsgAddSupportedMetadataSchema struct {
 	Signer sdk.AccAddress `json:"signer"`

--- a/x/docs/internal/types/msgs.go
+++ b/x/docs/internal/types/msgs.go
@@ -19,7 +19,7 @@ var algorithms = map[string]int{
 }
 
 // ----------------------------------
-// --- ShareDocument
+// --- MsgShareDocument
 // ----------------------------------
 
 type MsgShareDocument Document
@@ -41,14 +41,22 @@ func validateUuid(uuid string) bool {
 
 func validateDocMetadata(docMetadata DocumentMetadata) sdk.Error {
 	if len(docMetadata.ContentUri) == 0 {
-		return sdk.ErrUnknownRequest("Metadata content URI can't be empty")
+		return sdk.ErrUnknownRequest("MetadataSchema content URI can't be empty")
 	}
-	if len(docMetadata.Schema.Uri) == 0 {
-		return sdk.ErrUnknownRequest("Schema URI can't be empty")
+
+	if (docMetadata.Schema == nil) && len(docMetadata.SchemaType) == 0 {
+		return sdk.ErrUnknownRequest("Either schema or schema_type must be defined")
 	}
-	if len(docMetadata.Schema.Version) == 0 {
-		return sdk.ErrUnknownRequest("Schema version can't be empty")
+
+	if docMetadata.Schema != nil {
+		if len(docMetadata.Schema.Uri) == 0 {
+			return sdk.ErrUnknownRequest("Schema URI can't be empty")
+		}
+		if len(docMetadata.Schema.Version) == 0 {
+			return sdk.ErrUnknownRequest("Schema version can't be empty")
+		}
 	}
+
 	if len(docMetadata.Proof) == 0 {
 		return sdk.ErrUnknownRequest("Computation proof can't be empty")
 	}
@@ -123,7 +131,7 @@ func (msg MsgShareDocument) GetSigners() []sdk.AccAddress {
 }
 
 // ----------------------------------
-// --- DocumentReceipt
+// --- MsgSendDocumentReceipt
 // ----------------------------------
 
 type MsgSendDocumentReceipt DocumentReceipt
@@ -166,4 +174,40 @@ func (msg MsgSendDocumentReceipt) GetSignBytes() []byte {
 // GetSigners Implements Msg.
 func (msg MsgSendDocumentReceipt) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Sender}
+}
+
+// ----------------------------------
+// --- MsgAddSupportedMetadataSchema
+// ----------------------------------
+
+type MsgAddSupportedMetadataSchema struct {
+	Signer sdk.AccAddress `json:"signer"`
+	Schema MetadataSchema `json:"schema"`
+}
+
+// RouterKey Implements Msg.
+func (msg MsgAddSupportedMetadataSchema) Route() string { return ModuleName }
+
+// Type Implements Msg.
+func (msg MsgAddSupportedMetadataSchema) Type() string { return MsgTypeAddSupportedMetadataSchema }
+
+func (msg MsgAddSupportedMetadataSchema) ValidateBasic() sdk.Error {
+	if msg.Signer.Empty() {
+		return sdk.ErrInvalidAddress(msg.Signer.String())
+	}
+	if err := msg.Schema.Validate(); err != nil {
+		return sdk.ErrUnknownRequest(err.Error())
+	}
+
+	return nil
+}
+
+// GetSignBytes Implements Msg.
+func (msg MsgAddSupportedMetadataSchema) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
+}
+
+// GetSigners Implements Msg.
+func (msg MsgAddSupportedMetadataSchema) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.Signer}
 }

--- a/x/docs/internal/types/msgs.go
+++ b/x/docs/internal/types/msgs.go
@@ -146,6 +146,7 @@ func (msg MsgSendDocumentReceipt) Route() string { return ModuleName }
 // Type Implements Msg.
 func (msg MsgSendDocumentReceipt) Type() string { return MsgTypeSendDocumentReceipt }
 
+// ValidateBasic Implements Msg.
 func (msg MsgSendDocumentReceipt) ValidateBasic() sdk.Error {
 	if msg.Sender.Empty() {
 		return sdk.ErrInvalidAddress(msg.Sender.String())
@@ -191,6 +192,7 @@ func (msg MsgAddSupportedMetadataSchema) Route() string { return ModuleName }
 // Type Implements Msg.
 func (msg MsgAddSupportedMetadataSchema) Type() string { return MsgTypeAddSupportedMetadataSchema }
 
+// ValidateBasic Implements Msg.
 func (msg MsgAddSupportedMetadataSchema) ValidateBasic() sdk.Error {
 	if msg.Signer.Empty() {
 		return sdk.ErrInvalidAddress(msg.Signer.String())
@@ -198,7 +200,6 @@ func (msg MsgAddSupportedMetadataSchema) ValidateBasic() sdk.Error {
 	if err := msg.Schema.Validate(); err != nil {
 		return sdk.ErrUnknownRequest(err.Error())
 	}
-
 	return nil
 }
 
@@ -209,5 +210,43 @@ func (msg MsgAddSupportedMetadataSchema) GetSignBytes() []byte {
 
 // GetSigners Implements Msg.
 func (msg MsgAddSupportedMetadataSchema) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.Signer}
+}
+
+// -----------------------------------------
+// --- MsgAddTrustedMetadataSchemaProposer
+// -----------------------------------------
+
+type MsgAddTrustedMetadataSchemaProposer struct {
+	Proposer sdk.AccAddress `json:"proposer"`
+	Signer   sdk.AccAddress `json:"signer"`
+}
+
+// RouterKey Implements Msg.
+func (msg MsgAddTrustedMetadataSchemaProposer) Route() string { return ModuleName }
+
+// Type Implements Msg.
+func (msg MsgAddTrustedMetadataSchemaProposer) Type() string {
+	return MsgTypeAddTrustedMetadataSchemaProposer
+}
+
+// ValidateBasic Implements Msg.
+func (msg MsgAddTrustedMetadataSchemaProposer) ValidateBasic() sdk.Error {
+	if msg.Proposer.Empty() {
+		return sdk.ErrInvalidAddress(msg.Proposer.String())
+	}
+	if msg.Signer.Empty() {
+		return sdk.ErrInvalidAddress(msg.Signer.String())
+	}
+	return nil
+}
+
+// GetSignBytes Implements Msg.
+func (msg MsgAddTrustedMetadataSchemaProposer) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
+}
+
+// GetSigners Implements Msg.
+func (msg MsgAddTrustedMetadataSchemaProposer) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Signer}
 }

--- a/x/docs/internal/types/msgs_test.go
+++ b/x/docs/internal/types/msgs_test.go
@@ -45,31 +45,27 @@ var msgShareDocumentSchemaType = MsgShareDocument{
 }
 
 // ----------------------
-// --- Msg methods
+// --- MsgShareDocument
 // ----------------------
 
 func TestMsgShareDocument_Route(t *testing.T) {
 	actual := msgShareDocumentSchema.Route()
-	expected := ModuleName
-
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, QuerierRoute, actual)
 }
 
 func TestMsgShareDocument_Type(t *testing.T) {
 	actual := msgShareDocumentSchema.Type()
-	expected := MsgTypeShareDocument
-
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, MsgTypeShareDocument, actual)
 }
 
 func TestMsgShareDocument_ValidateBasic_Schema_valid(t *testing.T) {
-	actual := msgShareDocumentSchema.ValidateBasic()
-	assert.Nil(t, actual)
+	err := msgShareDocumentSchema.ValidateBasic()
+	assert.Nil(t, err)
 }
 
 func TestMsgShareDocument_ValidateBasic_SchemaType_valid(t *testing.T) {
-	actual := msgShareDocumentSchemaType.ValidateBasic()
-	assert.Nil(t, actual)
+	err := msgShareDocumentSchemaType.ValidateBasic()
+	assert.Nil(t, err)
 }
 
 func TestMsgShareDocument_ValidateBasic_invalid(t *testing.T) {
@@ -92,8 +88,8 @@ func TestMsgShareDocument_ValidateBasic_invalid(t *testing.T) {
 		},
 	}
 
-	actual := invalidMsg.ValidateBasic()
-	assert.NotNil(t, actual)
+	err := invalidMsg.ValidateBasic()
+	assert.NotNil(t, err)
 }
 
 func TestMsgShareDocument_GetSignBytes(t *testing.T) {
@@ -104,9 +100,8 @@ func TestMsgShareDocument_GetSignBytes(t *testing.T) {
 
 func TestMsgShareDocument_GetSigners(t *testing.T) {
 	actual := msgShareDocumentSchema.GetSigners()
-	expected := msgShareDocumentSchema.Sender
-
-	assert.Equal(t, expected, actual[0])
+	assert.Equal(t, 1, len(actual))
+	assert.Equal(t, msgShareDocumentSchema.Sender, actual[0])
 }
 
 func TestMsgShareDocument_UnmarshalJson_Schema(t *testing.T) {
@@ -299,9 +294,10 @@ func TestValidateChecksum_invalidChecksumLengths(t *testing.T) {
 	}
 }
 
-// ----------------------------------
-// --- DocumentReceipt tests
-// ----------------------------------
+// -----------------------------
+// --- MsgSendDocumentReceipt
+// -----------------------------
+
 var msgDocumentReceipt = MsgSendDocumentReceipt{
 	Sender:       sender,
 	Recipient:    recipient,
@@ -312,21 +308,17 @@ var msgDocumentReceipt = MsgSendDocumentReceipt{
 
 func TestMsgDocumentReceipt_Route(t *testing.T) {
 	actual := msgDocumentReceipt.Route()
-	expected := ModuleName
-
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, QuerierRoute, actual)
 }
 
 func TestMsgDocumentReceipt_Type(t *testing.T) {
 	actual := msgDocumentReceipt.Type()
-	expected := MsgTypeSendDocumentReceipt
-
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, MsgTypeSendDocumentReceipt, actual)
 }
 
 func TestMsgDocumentReceipt_ValidateBasic_valid(t *testing.T) {
-	actual := msgDocumentReceipt.ValidateBasic()
-	assert.Nil(t, actual)
+	err := msgDocumentReceipt.ValidateBasic()
+	assert.Nil(t, err)
 }
 
 func TestMsgDocumentReceipt_ValidateBasic_invalid(t *testing.T) {
@@ -337,9 +329,8 @@ func TestMsgDocumentReceipt_ValidateBasic_invalid(t *testing.T) {
 		DocumentUuid: "123456789",
 		Proof:        "proof",
 	}
-	actual := msgDocReceipt.ValidateBasic()
-
-	assert.NotNil(t, actual)
+	err := msgDocReceipt.ValidateBasic()
+	assert.NotNil(t, err)
 }
 
 func TestMsgDocumentReceipt_GetSignBytes(t *testing.T) {
@@ -350,7 +341,104 @@ func TestMsgDocumentReceipt_GetSignBytes(t *testing.T) {
 
 func TestMsgDocumentReceipt_GetSigners(t *testing.T) {
 	actual := msgDocumentReceipt.GetSigners()
-	expected := msgDocumentReceipt.Sender
+	assert.Equal(t, 1, len(actual))
+	assert.Equal(t, msgDocumentReceipt.Sender, actual[0])
+}
 
-	assert.Equal(t, expected, actual[0])
+// ------------------------------------
+// --- MsgAddSupportedMetadataSchema
+// ------------------------------------
+
+var msgAddSupportedMetadataSchema = MsgAddSupportedMetadataSchema{
+	Signer: sender,
+	Schema: MetadataSchema{
+		Type:      "schema",
+		SchemaUri: "https://example.com/schema",
+		Version:   "1.0.0",
+	},
+}
+
+func Test_MsgAddSupportedMetadataSchema_Route(t *testing.T) {
+	actual := msgAddSupportedMetadataSchema.Route()
+	assert.Equal(t, QuerierRoute, actual)
+}
+
+func Test_MsgAddSupportedMetadataSchema_Type(t *testing.T) {
+	actual := msgAddSupportedMetadataSchema.Type()
+	assert.Equal(t, MsgTypeAddSupportedMetadataSchema, actual)
+}
+
+func Test_MsgAddSupportedMetadataSchema_ValidateBasic_valid(t *testing.T) {
+	err := msgAddSupportedMetadataSchema.ValidateBasic()
+	assert.Nil(t, err)
+}
+
+func Test_MsgAddSupportedMetadataSchema_ValidateBasic_invalid(t *testing.T) {
+	var msgDocReceipt = MsgAddSupportedMetadataSchema{
+		Signer: recipient,
+		Schema: MetadataSchema{
+			Type:      "schema-2",
+			SchemaUri: "",
+			Version:   "",
+		},
+	}
+	err := msgDocReceipt.ValidateBasic()
+	assert.NotNil(t, err)
+}
+
+func Test_MsgAddSupportedMetadataSchema_GetSignBytes(t *testing.T) {
+	actual := msgAddSupportedMetadataSchema.GetSignBytes()
+	expected := sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msgAddSupportedMetadataSchema))
+	assert.Equal(t, expected, actual)
+}
+
+func Test_MsgAddSupportedMetadataSchema_GetSigners(t *testing.T) {
+	actual := msgAddSupportedMetadataSchema.GetSigners()
+	assert.Equal(t, 1, len(actual))
+	assert.Equal(t, msgAddSupportedMetadataSchema.Signer, actual[0])
+}
+
+// -----------------------------------------
+// --- MsgAddTrustedMetadataSchemaProposer
+// -----------------------------------------
+
+var msgAddTrustedMetadataSchemaProposer = MsgAddTrustedMetadataSchemaProposer{
+	Proposer: sender,
+	Signer:   recipient,
+}
+
+func Test_MsgAddTrustedMetadataSchemaProposer_Route(t *testing.T) {
+	actual := msgAddTrustedMetadataSchemaProposer.Route()
+	assert.Equal(t, QuerierRoute, actual)
+}
+
+func Test_MsgAddTrustedMetadataSchemaProposer_Type(t *testing.T) {
+	actual := msgAddTrustedMetadataSchemaProposer.Type()
+	assert.Equal(t, MsgTypeAddTrustedMetadataSchemaProposer, actual)
+}
+
+func Test_MsgAddTrustedMetadataSchemaProposer_ValidateBasic_valid(t *testing.T) {
+	err := msgAddTrustedMetadataSchemaProposer.ValidateBasic()
+	assert.Nil(t, err)
+}
+
+func Test_MsgAddTrustedMetadataSchemaProposer_ValidateBasic_invalid(t *testing.T) {
+	var msgDocReceipt = MsgAddTrustedMetadataSchemaProposer{
+		Proposer: nil,
+		Signer:   recipient,
+	}
+	err := msgDocReceipt.ValidateBasic()
+	assert.NotNil(t, err)
+}
+
+func Test_MsgAddTrustedMetadataSchemaProposer_GetSignBytes(t *testing.T) {
+	actual := msgAddTrustedMetadataSchemaProposer.GetSignBytes()
+	expected := sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msgAddTrustedMetadataSchemaProposer))
+	assert.Equal(t, expected, actual)
+}
+
+func Test_MsgAddTrustedMetadataSchemaProposer_GetSigners(t *testing.T) {
+	actual := msgAddTrustedMetadataSchemaProposer.GetSigners()
+	assert.Equal(t, 1, len(actual))
+	assert.Equal(t, msgAddTrustedMetadataSchemaProposer.Signer, actual[0])
 }

--- a/x/gencommands/client/cli/add_genesis_memberships_minter.go
+++ b/x/gencommands/client/cli/add_genesis_memberships_minter.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/commercionetwork/commercionetwork/x/memberships"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/tendermint/tendermint/libs/cli"
+
+	"github.com/cosmos/cosmos-sdk/client/keys"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+)
+
+// SetGenesisGovernmentAddressCmd returns add-genesis-minter cobra Command.
+func AddGenesisMembershipMinterCmd(ctx *server.Context, cdc *codec.Codec,
+	defaultNodeHome, defaultClientHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-genesis-membership-minter [minter_address_or_key]",
+		Short: "Add genesis membership minter to genesis.json",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			config := ctx.Config
+			config.SetRoot(viper.GetString(cli.HomeFlag))
+
+			minterAddr, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				kb, err := keys.NewKeyBaseFromDir(viper.GetString(flagClientHome))
+				if err != nil {
+					return err
+				}
+
+				info, err := kb.Get(args[0])
+				if err != nil {
+					return err
+				}
+
+				minterAddr = info.GetAddress()
+			}
+
+			// retrieve the app state
+			genFile := config.GenesisFile()
+			appState, genDoc, err := genutil.GenesisStateFromGenFile(cdc, genFile)
+			if err != nil {
+				return err
+			}
+
+			// add minter to the app state
+			var genState memberships.GenesisState
+
+			cdc.MustUnmarshalJSON(appState[memberships.ModuleName], &genState)
+
+			if genState.Minters.Contains(minterAddr) {
+				return fmt.Errorf("cannot add minter at existing address %v", minterAddr)
+			}
+
+			genState.Minters = append(genState.Minters, minterAddr)
+
+			genesisStateBz := cdc.MustMarshalJSON(genState)
+			appState[memberships.ModuleName] = genesisStateBz
+
+			appStateJSON, err := cdc.MarshalJSON(appState)
+			if err != nil {
+				return err
+			}
+
+			// export app state
+			genDoc.AppState = appStateJSON
+
+			return genutil.ExportGenesisFile(genDoc, genFile)
+		},
+	}
+
+	cmd.Flags().String(cli.HomeFlag, defaultNodeHome, "node's home directory")
+	cmd.Flags().String(flagClientHome, defaultClientHome, "client's home directory")
+	return cmd
+}

--- a/x/gencommands/client/cli/keys.goo.go
+++ b/x/gencommands/client/cli/keys.goo.go
@@ -1,0 +1,5 @@
+package cli
+
+const (
+	flagClientHome = "home-client"
+)

--- a/x/government/alias.go
+++ b/x/government/alias.go
@@ -1,0 +1,23 @@
+package government
+
+import (
+	"github.com/commercionetwork/commercionetwork/x/government/internal/keeper"
+	"github.com/commercionetwork/commercionetwork/x/government/internal/types"
+)
+
+const (
+	ModuleName   = types.ModuleName
+	StoreKey     = types.StoreKey
+	QuerierRoute = types.QuerierRoute
+)
+
+var (
+	NewKeeper     = keeper.NewKeeper
+	NewQuerier    = keeper.NewQuerier
+	RegisterCodec = types.RegisterCodec
+	ModuleCdc     = types.ModuleCdc
+)
+
+type (
+	Keeper = keeper.Keeper
+)

--- a/x/government/genesis.go
+++ b/x/government/genesis.go
@@ -1,0 +1,38 @@
+package government
+
+import (
+	"errors"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// GenesisState - docs genesis state
+type GenesisState struct {
+	GovernmentAddress sdk.AccAddress `json:"government_address"`
+}
+
+// DefaultGenesisState returns a default genesis state
+func DefaultGenesisState() GenesisState {
+	return GenesisState{}
+}
+
+// InitGenesis sets docs information for genesis.
+func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {
+	keeper.SetGovernmentAddress(ctx, data.GovernmentAddress)
+}
+
+// ExportGenesis returns a GenesisState for a given context and keeper.
+func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
+	return GenesisState{
+		GovernmentAddress: keeper.GetGovernmentAddress(ctx),
+	}
+}
+
+// ValidateGenesis performs basic validation of genesis data returning an
+// error for any failed validation criteria.
+func ValidateGenesis(data GenesisState) error {
+	if data.GovernmentAddress.Empty() {
+		return errors.New("government address cannot be empty. Use the set-genesis-government-address command to set one")
+	}
+	return nil
+}

--- a/x/government/internal/keeper/keeper.go
+++ b/x/government/internal/keeper/keeper.go
@@ -1,0 +1,32 @@
+package keeper
+
+import (
+	"github.com/commercionetwork/commercionetwork/x/government/internal/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type Keeper struct {
+	StoreKey sdk.StoreKey
+	cdc      *codec.Codec
+}
+
+func NewKeeper(storeKey sdk.StoreKey, cdc *codec.Codec) Keeper {
+	return Keeper{
+		StoreKey: storeKey,
+		cdc:      cdc,
+	}
+}
+
+// SetGovernmentAddress allows to set the given address as the one that
+// the government will use later
+func (keeper Keeper) SetGovernmentAddress(ctx sdk.Context, address sdk.AccAddress) {
+	store := ctx.KVStore(keeper.StoreKey)
+	store.Set([]byte(types.GovernmentStoreKey), address)
+}
+
+// GetGovernmentAddress returns the address that the government has currently
+func (keeper Keeper) GetGovernmentAddress(ctx sdk.Context) sdk.AccAddress {
+	store := ctx.KVStore(keeper.StoreKey)
+	return store.Get([]byte(types.GovernmentStoreKey))
+}

--- a/x/government/internal/keeper/keeper_test.go
+++ b/x/government/internal/keeper/keeper_test.go
@@ -1,0 +1,29 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/commercionetwork/commercionetwork/x/government/internal/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeeper_SetGovernmentAddress(t *testing.T) {
+	input := setupTestInput()
+
+	input.Keeper.SetGovernmentAddress(input.Ctx, TestAddress)
+
+	store := input.Ctx.KVStore(input.Keeper.StoreKey)
+	stored := sdk.AccAddress(store.Get([]byte(types.GovernmentStoreKey)))
+	assert.Equal(t, TestAddress, stored)
+}
+
+func TestKeeper_GetGovernmentAddress(t *testing.T) {
+	input := setupTestInput()
+	store := input.Ctx.KVStore(input.Keeper.StoreKey)
+	store.Set([]byte(types.GovernmentStoreKey), TestAddress)
+
+	actual := input.Keeper.GetGovernmentAddress(input.Ctx)
+
+	assert.Equal(t, TestAddress, actual)
+}

--- a/x/government/internal/keeper/querier.go
+++ b/x/government/internal/keeper/querier.go
@@ -1,0 +1,34 @@
+package keeper
+
+import (
+	"fmt"
+
+	"github.com/commercionetwork/commercionetwork/x/government/internal/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+// NewQuerier is the module level router for state queries
+func NewQuerier(keeper Keeper) sdk.Querier {
+	return func(ctx sdk.Context, path []string, req abci.RequestQuery) (res []byte, err sdk.Error) {
+		switch path[0] {
+		case types.QueryGovernmentAddress:
+			return queryGetReceivedDocuments(ctx, path[1:], keeper)
+		default:
+			return nil, sdk.ErrUnknownRequest(fmt.Sprintf("Unknown %s query endpoint", types.ModuleName))
+		}
+	}
+}
+
+func queryGetReceivedDocuments(ctx sdk.Context, path []string, keeper Keeper) ([]byte, sdk.Error) {
+	address := keeper.GetGovernmentAddress(ctx)
+
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, address)
+	if err != nil {
+		return nil, sdk.ErrUnknownRequest("Could not marshal result to JSON")
+	}
+
+	return bz, nil
+}

--- a/x/government/internal/keeper/test_commons.go
+++ b/x/government/internal/keeper/test_commons.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"github.com/commercionetwork/commercionetwork/x/docs/internal/types"
-	"github.com/commercionetwork/commercionetwork/x/government"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,14 +14,14 @@ import (
 
 var TestUtils = setupTestInput()
 
-type testInput struct {
-	Cdc        *codec.Codec
-	Ctx        sdk.Context
-	DocsKeeper Keeper
+type TestInput struct {
+	Cdc    *codec.Codec
+	Ctx    sdk.Context
+	Keeper Keeper
 }
 
 //This function create an enviroment to test modules
-func setupTestInput() testInput {
+func setupTestInput() TestInput {
 
 	memDB := db.NewMemDB()
 	cdc := testCodec()
@@ -49,13 +47,12 @@ func setupTestInput() testInput {
 
 	ctx := sdk.NewContext(ms, abci.Header{ChainID: "test-chain-id"}, false, log.NewNopLogger())
 
-	govk := government.NewKeeper(keyGovernment, cdc)
-	dck := NewKeeper(keyDocs, govk, cdc)
+	govk := NewKeeper(keyGovernment, cdc)
 
-	return testInput{
-		Cdc:        cdc,
-		Ctx:        ctx,
-		DocsKeeper: dck,
+	return TestInput{
+		Cdc:    cdc,
+		Ctx:    ctx,
+		Keeper: govk,
 	}
 }
 
@@ -71,33 +68,4 @@ func testCodec() *codec.Codec {
 }
 
 // Testing variables
-
-var TestingSender, _ = sdk.AccAddressFromBech32("cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0")
-var TestingSender2, _ = sdk.AccAddressFromBech32("cosmos1nynns8ex9fq6sjjfj8k79ymkdz4sqth06xexae")
-var TestingRecipient, _ = sdk.AccAddressFromBech32("cosmos1tupew4x3rhh0lpqha9wvzmzxjr4e37mfy3qefm")
-
-var TestingDocument = types.Document{
-	Sender:     TestingSender,
-	Recipient:  TestingRecipient,
-	ContentUri: "https://example.com/document",
-	Metadata: types.DocumentMetadata{
-		ContentUri: "",
-		Schema: &types.DocumentMetadataSchema{
-			Uri:     "https://example.com/document/metadata/schema",
-			Version: "1.0.0",
-		},
-		Proof: "73666c68676c7366676c7366676c6a6873666c6a6768",
-	},
-	Checksum: types.DocumentChecksum{
-		Value:     "93dfcaf3d923ec47edb8580667473987",
-		Algorithm: "md5",
-	},
-}
-
-var TestingDocumentReceipt = types.DocumentReceipt{
-	Sender:       TestingSender,
-	Recipient:    TestingRecipient,
-	TxHash:       "txHash",
-	DocumentUuid: "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
-	Proof:        "proof",
-}
+var TestAddress, _ = sdk.AccAddressFromBech32("cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0")

--- a/x/government/internal/types/codec.go
+++ b/x/government/internal/types/codec.go
@@ -1,0 +1,17 @@
+package types
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+)
+
+// RegisterCodec registers concrete types on wire codec
+func RegisterCodec(_ *codec.Codec) {}
+
+var ModuleCdc *codec.Codec
+
+func init() {
+	ModuleCdc = codec.New()
+	RegisterCodec(ModuleCdc)
+	codec.RegisterCrypto(ModuleCdc)
+	ModuleCdc.Seal()
+}

--- a/x/government/internal/types/keys.go
+++ b/x/government/internal/types/keys.go
@@ -1,0 +1,11 @@
+package types
+
+const (
+	ModuleName   = "government"
+	StoreKey     = ModuleName
+	QuerierRoute = ModuleName
+
+	GovernmentStoreKey = StoreKey + "government"
+
+	QueryGovernmentAddress = "governmentAddress"
+)

--- a/x/government/module.go
+++ b/x/government/module.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 
 	"github.com/commercionetwork/commercionetwork/x/docs/client/cli"
-	"github.com/commercionetwork/commercionetwork/x/docs/client/rest"
 )
 
 var (
@@ -55,7 +54,6 @@ func (AppModuleBasic) ValidateGenesis(bz json.RawMessage) error {
 
 // register rest routes
 func (AppModuleBasic) RegisterRESTRoutes(ctx context.CLIContext, rtr *mux.Router) {
-	rest.RegisterRoutes(ctx, rtr)
 }
 
 // get the root tx command of this module

--- a/x/government/module.go
+++ b/x/government/module.go
@@ -1,4 +1,4 @@
-package docs
+package government
 
 import (
 	"encoding/json"
@@ -109,7 +109,7 @@ func (AppModule) Route() string {
 
 // module handler
 func (am AppModule) NewHandler() sdk.Handler {
-	return NewHandler(am.keeper)
+	return nil
 }
 
 // module querier route name
@@ -138,7 +138,6 @@ func (am AppModule) ExportGenesis(ctx sdk.Context) json.RawMessage {
 
 // module begin-block
 func (am AppModule) BeginBlock(ctx sdk.Context, rbb abci.RequestBeginBlock) {
-	BeginBlocker(ctx, rbb, am.keeper)
 }
 
 // module end-block

--- a/x/id/internal/types/codec.go
+++ b/x/id/internal/types/codec.go
@@ -6,7 +6,7 @@ import (
 
 // RegisterCodec registers concrete types on wire codec
 func RegisterCodec(cdc *codec.Codec) {
-	cdc.RegisterConcrete(MsgSetIdentity{}, "commercio/SetIdentity", nil)
+	cdc.RegisterConcrete(MsgSetIdentity{}, "commercio/MsgSetIdentity", nil)
 }
 
 var ModuleCdc *codec.Codec

--- a/x/id/internal/types/msgs_test.go
+++ b/x/id/internal/types/msgs_test.go
@@ -56,7 +56,7 @@ func TestMsgSetIdentity_ValidateBasic_InvalidDidDocumentUri(t *testing.T) {
 }
 
 func TestMsgSetIdentity_GetSignBytes(t *testing.T) {
-	expected := `{"type":"commercio/SetIdentity","value":{"did_document_uri":"https://test.example.com/did-document#1","owner":"cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0"}}`
+	expected := `{"type":"commercio/MsgSetIdentity","value":{"did_document_uri":"https://test.example.com/did-document#1","owner":"cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0"}}`
 
 	actual := msgSetId.GetSignBytes()
 	assert.Equal(t, expected, string(actual))

--- a/x/memberships/internal/keeper/keeper.go
+++ b/x/memberships/internal/keeper/keeper.go
@@ -37,7 +37,7 @@ func (keeper Keeper) AddTrustedMinter(ctx sdk.Context, minter sdk.AccAddress) {
 	store := ctx.KVStore(keeper.StoreKey)
 
 	// Save the minter
-	key := []byte(types.TrustworthyMinterPrefix + minter.String())
+	key := []byte(types.TrustedMinterPrefix + minter.String())
 	store.Set(key, minter)
 }
 
@@ -49,7 +49,7 @@ func (keeper Keeper) GetTrustedMinters(ctx sdk.Context) types.Minters {
 	var minters []sdk.AccAddress
 
 	// Iterate over all the keys having the minter prefix
-	iterator := sdk.KVStorePrefixIterator(store, []byte(types.TrustworthyMinterPrefix))
+	iterator := sdk.KVStorePrefixIterator(store, []byte(types.TrustedMinterPrefix))
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		// Add each minter to the list

--- a/x/memberships/internal/keeper/keeper_test.go
+++ b/x/memberships/internal/keeper/keeper_test.go
@@ -12,19 +12,19 @@ import (
 
 func TestKeeper_AddTrustedMinter(t *testing.T) {
 	membershipsStore := TestUtils.Ctx.KVStore(TestUtils.MembershipKeeper.StoreKey)
-	storeData := membershipsStore.Get([]byte(types.TrustworthyMinterPrefix + TestSignerAddress.String()))
+	storeData := membershipsStore.Get([]byte(types.TrustedMinterPrefix + TestSignerAddress.String()))
 	assert.Nil(t, storeData)
 
 	TestUtils.MembershipKeeper.AddTrustedMinter(TestUtils.Ctx, TestSignerAddress)
 
-	afterOpLen := membershipsStore.Get([]byte(types.TrustworthyMinterPrefix + TestSignerAddress.String()))
+	afterOpLen := membershipsStore.Get([]byte(types.TrustedMinterPrefix + TestSignerAddress.String()))
 	assert.Equal(t, TestSignerAddress.Bytes(), afterOpLen)
 }
 
 func TestKeeper_GetTrustedMinters(t *testing.T) {
 	membershipsStore := TestUtils.Ctx.KVStore(TestUtils.MembershipKeeper.StoreKey)
-	membershipsStore.Set([]byte(types.TrustworthyMinterPrefix+TestSignerAddress.String()), TestSignerAddress.Bytes())
-	membershipsStore.Set([]byte(types.TrustworthyMinterPrefix+TestUserAddress.String()), TestUserAddress.Bytes())
+	membershipsStore.Set([]byte(types.TrustedMinterPrefix+TestSignerAddress.String()), TestSignerAddress.Bytes())
+	membershipsStore.Set([]byte(types.TrustedMinterPrefix+TestUserAddress.String()), TestUserAddress.Bytes())
 
 	minters := TestUtils.MembershipKeeper.GetTrustedMinters(TestUtils.Ctx)
 

--- a/x/memberships/internal/types/keys.go
+++ b/x/memberships/internal/types/keys.go
@@ -6,7 +6,7 @@ const (
 	RouterKey    = ModuleName
 	QuerierRoute = ModuleName
 
-	TrustworthyMinterPrefix = "minter:"
+	TrustedMinterPrefix = "minter:"
 
 	NftDenom = "membership"
 


### PR DESCRIPTION
### Changes
* Added the `government` module
* Added the `set-genesis-government-address` command that **must** be run during genesis creation
* Added the support for officially-recognized document metadata schema
* Added the `MsgAddSupportedMetadataSchema` message 
* Added the `MsgAddTrustedMetadataSchemaProposer` message
* Added some REST endpoints and improved the existing ones
* Added some CLI commands and improved the existing ones
* Added missing tests
* Updated the docs