### PR TITLE
CommercioDOCS improvements

### DIFF
--- a/cmd/cncli/main.go
+++ b/cmd/cncli/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/commercionetwork/commercionetwork/app"
 	"os"
 	"path"
+
+	"github.com/commercionetwork/commercionetwork/app"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -47,7 +48,6 @@ func main() {
 	config.SetBech32PrefixForConsensusNode(app.Bech32PrefixConsAddr, app.Bech32PrefixConsPub)
 	config.Seal()
 
-	// TODO: setup keybase, viper object, etc. to be passed into
 	// the below functions and eliminate global vars, like we do
 	// with the cdc
 	rootCmd := &cobra.Command{

--- a/docs/x/docs/tx/share-document.md
+++ b/docs/x/docs/tx/share-document.md
@@ -9,27 +9,44 @@ following message:
 
 ```json
 {
-  "type": "commercio/MsgSendDocument",
+  "type": "commercio/MsgShareDocument",
   "value": {
-    "sender": "<Your address>",
-    "recipient": "<Recipient address>",
-    "uuid": "<Document UUID>",
-    "content_uri": "<Document content URI>",
-    "metadata": {
-      "content_uri": "<Metadata content URI>",
-      "schema_type": "<Officially recognized schema type>",
-      "schema": {
-        "uri": "<Metadata schema URI>",
-        "version": "<Metadata schema version>"
+    "sender": "cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0",
+    "recipients": [
+      "<Recipient address>"
+    ],
+    "document": {
+      "uuid": "<Document UUID>",
+      "content_uri": "<Document content URI>",
+      "metadata": {
+        "content_uri": "<Metadata content URI>",
+        "schema": {
+          "uri": "<Metadata schema definition URI>",
+          "version": "<Metadata schema version>"
+        },
+        "schema_type": "<Metadata schema type>",
+        "proof": "<Metadata verification proof>"
       },
-      "proof": "<Metadata validation proof>"
-    },
-    "checksum": {
-      "value": "<Document content checksum value>",
-      "algorithm": "<Checksum algorithm>"
+      "checksum": {
+        "value": "<Document content checksum value>",
+        "algorithm": "<Document content checksum algorithm>"
+      },
+      "encryption_data": {
+        "keys": [
+          {
+            "recipient": "<Recipient address>",
+            "value": "<Encrypted and encoded symmetric key value>",
+            "encoding": "<Encoding algorithm>"
+          }
+        ],
+        "encrypted_data": [
+          "<Encrypted field identifier>"
+        ]
+      }
     }
   }
 }
+
 ```
 
 ### Notes
@@ -40,7 +57,92 @@ following message:
 3. You can read which `checksum.algorithm` values are supported inside the
    [supported checksum algorithms section](#supported-checksum-algorithm)  
 
-## Using the CLI 
+## Supported checksum algorithm
+When computing the checksum of a document's contents, you must use one of the following supported checksum algorithms.  
+Not using one of these will result in your transaction being rejected or mishandled by recipients. 
+
+| Algorithm | Specification |
+| :-------: | :-----------: |
+| `md5` | [MD5](https://www.ietf.org/rfc/rfc1321.txt) |
+| `sha-1`| [SHA-1](https://tools.ietf.org/html/rfc3174) |
+| `sha-224` | [RFC 4634](https://tools.ietf.org/html/rfc4634) |
+| `sha-256` | [RFC 4634](https://tools.ietf.org/html/rfc4634) |
+| `sha-384` | [RFC 4634](https://tools.ietf.org/html/rfc4634) |
+| `sha-512` | [RFC 4634](https://tools.ietf.org/html/rfc4634) |
+
+#### Checksum validity check
+Please note that, when sending a document that has an associated checksum, the validity of the checksum itself is
+checked only formally. This means that we only check that the hash value has a valid length, but we do not check 
+if the given has is indeed the hash of the document's content. It should be the client responsibility to perform this 
+check.      
+
+## Encrypting the data
+In order to properly encrypting the data that you want to avoid being shared publicly, 
+the following procedure must be followed. 
+
+1. Generate a safe AES-256 encryption key. A key size of 256 bits is recommended.
+   ```
+   aes_key = get_random_aes_key(key_size = 256)
+   ```
+
+2. Use the AES key to encrypt the data you desire using the AES-256 CBC method.  
+   ```
+   encrypted_data = aes_encrypt_cbc(
+     key = aes_key, 
+     initialization_vector = null
+   )
+   ```
+   
+3. Encrypt the AES-256 key using the recipient's public encryption key  
+   ```
+   encrypted_aes_key = rsa_encrypt(
+     key = recipient.public_rsa_encryption_key,
+     value = aes_key
+   )    
+   ```
+   
+4. Encode the encrypted AES-256 key  
+   ```
+   encoded_encryption_key = hex_encode(encrypted_aes_key)
+   ```
+   
+4. Compose the encryption data  
+   ```json
+   {
+     "encryption_data": {
+       "keys": [
+         {
+           "recipient": "<recipient_address>",
+           "value": "<encoded_encryption_key>",
+           "encoding": "hex"
+         }
+       ],
+       "encrypted_data": [
+         "<Your encrypted data identifier>"
+       ]
+     }
+   }
+   ```
+   
+### Supported encoding methods
+Currently only the following encoding methods are supported then encoding the encrypted AES-256 key:
+
+* `hex`
+* `baes64`  
+   
+### Supported encrypted data
+Please note that when specifying which data you have encrypted for the document recipient, you need to use one or 
+more of the following identifiers inside the `encryption_data.encrypted_data` field.  
+Inserting other non supported values inside such a field will result in the transactions being rejected as not valid.   
+
+| Identifier | Referenced data | 
+| :--------: | :-------------- |
+| `content` | Document's file contents |
+| `content_uri` | Value of the `content_uri` field |
+| `metadata.content_uri` | Value of the `content_uri` field inside the `metadata` object |
+| `metadata.schema.uri` | Value of the `uri` field inside the `metadata`'s `schema` sub-object |
+
+## ⚠️ OUTDATED ⚠️ Using the CLI
 In order to send a document using the CLI you can use the following command 
 
 ```bash
@@ -84,23 +186,3 @@ cncli tx commerciodocs share \
   md5 \
   --from jack
 ```
-
-## Supported checksum algorithm
-When computing the checksum of a document's contents, you must use one of the following supported checksum algorithms.  
-Not using one of these will result in your transaction being rejected or mishandled by recipients. 
-
-| Algorithm | Specification |
-| :-------: | :-----------: |
-| `md5` | [MD5](https://www.ietf.org/rfc/rfc1321.txt) |
-| `sha-1`| [SHA-1](https://tools.ietf.org/html/rfc3174) |
-| `sha-224` | [RFC 4634](https://tools.ietf.org/html/rfc4634) |
-| `sha-256` | [RFC 4634](https://tools.ietf.org/html/rfc4634) |
-| `sha-384` | [RFC 4634](https://tools.ietf.org/html/rfc4634) |
-| `sha-512` | [RFC 4634](https://tools.ietf.org/html/rfc4634) |
-
-#### Checksum validity check
-Please note that, when sending a document that has an associated checksum, the validity of the checksum itself is
-checked only formally. This means that we only check that the hash value has a valid length, but we do not check 
-if the given has is indeed the hash of the document's content. It should be the client responsibility to perform this 
-check.  
-

--- a/docs/x/docs/tx/share-document.md
+++ b/docs/x/docs/tx/share-document.md
@@ -142,7 +142,12 @@ Inserting other non supported values inside such a field will result in the tran
 | `metadata.content_uri` | Value of the `content_uri` field inside the `metadata` object |
 | `metadata.schema.uri` | Value of the `uri` field inside the `metadata`'s `schema` sub-object |
 
-## ⚠️ OUTDATED ⚠️ Using the CLI
+## Using the CLI
+
+:::danger  
+Please note that the following procedure is completely outdated and should not be used  
+:::
+
 In order to send a document using the CLI you can use the following command 
 
 ```bash

--- a/x/accreditations/handler_test.go
+++ b/x/accreditations/handler_test.go
@@ -14,9 +14,6 @@ import (
 func Test_handleSetAccrediter_NotTrustedAccrediter(t *testing.T) {
 	ctx, _, _, _, governmentKeeper, accreditationKeeper := GetTestInput()
 
-	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete([]byte(TrustedSignersStoreKey))
-
 	handler := NewHandler(accreditationKeeper, governmentKeeper)
 	msg := MsgSetAccrediter{User: TestUser, Accrediter: TestAccrediter, Signer: TestSigner}
 	res := handler(ctx, msg)
@@ -62,9 +59,6 @@ func Test_handleSetAccrediter_ValidData(t *testing.T) {
 
 func Test_handleDistributeReward_NilAccrediter(t *testing.T) {
 	ctx, _, _, _, governmentKeeper, accreditationKeeper := GetTestInput()
-
-	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete(TestUser)
 
 	handler := NewHandler(accreditationKeeper, governmentKeeper)
 	reward := sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(100)))

--- a/x/accreditations/internal/keeper/keeper.go
+++ b/x/accreditations/internal/keeper/keeper.go
@@ -148,7 +148,7 @@ func (keeper Keeper) DistributeReward(ctx sdk.Context, accrediter sdk.AccAddress
 
 	// Save the updated pool
 	if liquidity.Empty() {
-		store.Delete([]byte(types.LiquidityPoolKey))
+
 	} else {
 		store.Set([]byte(types.LiquidityPoolKey), keeper.cdc.MustMarshalBinaryBare(&liquidity))
 	}

--- a/x/accreditations/internal/keeper/keeper_test.go
+++ b/x/accreditations/internal/keeper/keeper_test.go
@@ -17,7 +17,6 @@ func TestKeeper_SetAccrediter_NoAccrediter(t *testing.T) {
 	ctx, cdc, _, _, _, accreditationKeeper := GetTestInput()
 
 	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete(TestUser)
 
 	err := accreditationKeeper.SetAccrediter(ctx, TestUser, TestAccrediter)
 	assert.Nil(t, err)
@@ -52,9 +51,6 @@ func TestKeeper_SetAccrediter_ExistingAccrediter(t *testing.T) {
 func TestKeeper_GetAccreditation_NoAccrediter(t *testing.T) {
 	ctx, _, _, _, _, accreditationKeeper := GetTestInput()
 
-	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete(TestUser)
-
 	accreditation := accreditationKeeper.GetAccreditation(ctx, TestUser)
 	assert.Equal(t, types.Accreditation{}, accreditation)
 }
@@ -85,7 +81,7 @@ func TestKeeper_GetAccreditations_EmptyList(t *testing.T) {
 	store := ctx.KVStore(accreditationKeeper.StoreKey)
 	iterator := store.Iterator(nil, nil)
 	for ; iterator.Valid(); iterator.Next() {
-		store.Delete(iterator.Key())
+
 	}
 
 	accreditations := accreditationKeeper.GetAccreditations(ctx)
@@ -119,7 +115,6 @@ func TestKeeper_DepositIntoPool_EmptyPool(t *testing.T) {
 	_ = bankKeeper.SetCoins(ctx, TestUser, coins)
 
 	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete([]byte(types.LiquidityPoolKey))
 
 	deposit := sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(100)))
 	err := accreditationKeeper.DepositIntoPool(ctx, TestUser, deposit)
@@ -161,7 +156,6 @@ func TestKeeper_SetPoolFunds_EmptyPool(t *testing.T) {
 	ctx, cdc, _, _, _, accreditationKeeper := GetTestInput()
 
 	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete([]byte(types.LiquidityPoolKey))
 
 	deposit := sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(100)))
 	accreditationKeeper.SetPoolFunds(ctx, deposit)
@@ -194,9 +188,6 @@ func TestKeeper_SetPoolFunds_ExistingPool(t *testing.T) {
 func TestKeeper_GetPoolFunds_EmptyPool(t *testing.T) {
 	ctx, _, _, _, _, accreditationKeeper := GetTestInput()
 
-	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete([]byte(types.LiquidityPoolKey))
-
 	pool := accreditationKeeper.GetPoolFunds(ctx)
 
 	assert.Empty(t, pool)
@@ -228,7 +219,7 @@ func TestKeeper_AddTrustworthySigner_EmptyList(t *testing.T) {
 	store := ctx.KVStore(accreditationKeeper.StoreKey)
 	iterator := store.Iterator(nil, nil)
 	for ; iterator.Valid(); iterator.Next() {
-		store.Delete(iterator.Key())
+
 	}
 
 	accreditationKeeper.AddTrustedSigner(ctx, TestSigner)
@@ -247,7 +238,7 @@ func TestKeeper_AddTrustworthySigner_ExistingList(t *testing.T) {
 	store := ctx.KVStore(accreditationKeeper.StoreKey)
 	iterator := store.Iterator(nil, nil)
 	for ; iterator.Valid(); iterator.Next() {
-		store.Delete(iterator.Key())
+
 	}
 
 	signers := ctypes.Addresses{TestSigner}
@@ -271,7 +262,7 @@ func TestKeeper_GetTrustworthySigners_EmptyList(t *testing.T) {
 
 	iterator := store.Iterator(nil, nil)
 	for ; iterator.Valid(); iterator.Next() {
-		store.Delete(iterator.Key())
+
 	}
 
 	signers := accreditationKeeper.GetTrustedSigners(ctx)
@@ -285,7 +276,7 @@ func TestKeeper_GetTrustworthySigners_ExistingList(t *testing.T) {
 	store := ctx.KVStore(accreditationKeeper.StoreKey)
 	iterator := store.Iterator(nil, nil)
 	for ; iterator.Valid(); iterator.Next() {
-		store.Delete(iterator.Key())
+
 	}
 
 	signers := ctypes.Addresses{TestSigner, TestUser, TestAccrediter}
@@ -304,7 +295,7 @@ func TestKeeper_IsTrustworthySigner_EmptyList(t *testing.T) {
 	store := ctx.KVStore(accreditationKeeper.StoreKey)
 	iterator := store.Iterator(nil, nil)
 	for ; iterator.Valid(); iterator.Next() {
-		store.Delete(iterator.Key())
+
 	}
 
 	assert.False(t, accreditationKeeper.IsTrustedSigner(ctx, TestSigner))
@@ -318,7 +309,7 @@ func TestKeeper_IsTrustworthySigner_ExistingList(t *testing.T) {
 	store := ctx.KVStore(accreditationKeeper.StoreKey)
 	iterator := store.Iterator(nil, nil)
 	for ; iterator.Valid(); iterator.Next() {
-		store.Delete(iterator.Key())
+
 	}
 
 	signers := ctypes.Addresses{TestUser, TestSigner}
@@ -369,9 +360,6 @@ func TestKeeper_DistributeReward_NegativeReward(t *testing.T) {
 func TestKeeper_DistributeReward_NoAccrediter(t *testing.T) {
 	ctx, _, _, _, _, accreditationKeeper := GetTestInput()
 
-	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete(TestUser)
-
 	reward := sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(100)))
 	err := accreditationKeeper.DistributeReward(ctx, TestAccrediter, reward, TestUser)
 
@@ -398,7 +386,6 @@ func TestKeeper_DistributeReward_EmptyPool(t *testing.T) {
 	ctx, cdc, _, _, _, accreditationKeeper := GetTestInput()
 
 	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete([]byte(types.LiquidityPoolKey))
 
 	accreditation := types.Accreditation{Accrediter: TestAccrediter, User: TestUser, Rewarded: false}
 	store.Set(TestUser, cdc.MustMarshalBinaryBare(&accreditation))

--- a/x/accreditations/internal/keeper/querier_test.go
+++ b/x/accreditations/internal/keeper/querier_test.go
@@ -16,9 +16,6 @@ import (
 func Test_queryGetAccrediter_NonExistent(t *testing.T) {
 	ctx, cdc, _, _, _, accreditationKeeper := GetTestInput()
 
-	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete(TestUser)
-
 	path := []string{types.QueryGetAccrediter, TestUser.String()}
 
 	var querier = NewQuerier(accreditationKeeper)
@@ -59,9 +56,6 @@ func Test_queryGetAccrediter_Existent(t *testing.T) {
 
 func Test_queryGetSigners_EmptyList(t *testing.T) {
 	ctx, cdc, _, _, _, accreditationKeeper := GetTestInput()
-
-	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete([]byte(types.TrustedSignersStoreKey))
 
 	path := []string{types.QueryGetSigners}
 
@@ -104,9 +98,6 @@ func Test_queryGetSigners_ExistingList(t *testing.T) {
 
 func Test_queryGetPoolFunds_EmptyPool(t *testing.T) {
 	ctx, cdc, _, _, _, accreditationKeeper := GetTestInput()
-
-	store := ctx.KVStore(accreditationKeeper.StoreKey)
-	store.Delete([]byte(types.LiquidityPoolKey))
 
 	path := []string{types.QueryGetPoolFunds}
 

--- a/x/accreditations/module.go
+++ b/x/accreditations/module.go
@@ -62,8 +62,7 @@ func (AppModuleBasic) GetTxCmd(cdc *codec.Codec) *cobra.Command {
 
 // get the root query command of this module
 func (AppModuleBasic) GetQueryCmd(cdc *codec.Codec) *cobra.Command {
-	// TODO - return cli.GetQueryCmd(cdc)
-	return nil
+	return cli.GetQueryCmd(cdc)
 }
 
 //____________________________________________________________________________

--- a/x/common/types/addresses.go
+++ b/x/common/types/addresses.go
@@ -27,3 +27,7 @@ func (addresses Addresses) Contains(address sdk.Address) bool {
 	}
 	return false
 }
+
+func (addresses Addresses) Empty() bool {
+	return len(addresses) == 0
+}

--- a/x/docs/alias.go
+++ b/x/docs/alias.go
@@ -9,19 +9,32 @@ const (
 	ModuleName   = types.ModuleName
 	StoreKey     = types.StoreKey
 	QuerierRoute = types.QuerierRoute
+
+	MetadataSchemaProposersStoreKey = types.MetadataSchemaProposersStoreKey
 )
 
 var (
 	NewKeeper     = keeper.NewKeeper
 	NewQuerier    = keeper.NewQuerier
-	TestSetup     = keeper.SetupTestInput
 	RegisterCodec = types.RegisterCodec
 	ModuleCdc     = types.ModuleCdc
+
+	NewMsgShareDocument = types.NewMsgShareDocument
+
+	SetupTestInput         = keeper.SetupTestInput
+	TestingSender          = keeper.TestingSender
+	TestingRecipient       = keeper.TestingRecipient
+	TestingDocument        = keeper.TestingDocument
+	TestingDocumentReceipt = keeper.TestingDocumentReceipt
 )
 
 type (
 	Keeper                              = keeper.Keeper
 	Document                            = types.Document
+	DocumentMetadata                    = types.DocumentMetadata
+	MetadataSchema                      = types.MetadataSchema
+	DocumentChecksum                    = types.DocumentChecksum
+	DocumentIds                         = types.DocumentIds
 	DocumentReceipt                     = types.DocumentReceipt
 	MsgShareDocument                    = types.MsgShareDocument
 	MsgSendDocumentReceipt              = types.MsgSendDocumentReceipt

--- a/x/docs/client/cli/tx.go
+++ b/x/docs/client/cli/tx.go
@@ -33,11 +33,11 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 func getCmdShareDocument(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "share [recipient] [document-uuid] [document-metadata-uri] " +
-			"[metadata-schema-uri] [metadata-schema-version] [metadata-verification-proof] " +
+			"[metadata-schema-uri] [metadata-schema-version] " +
 			"[document-content-uri]" +
 			"[checksum-value] [checksum-algorithm]",
 		Short: "Shares the document with the given recipient address",
-		Args:  cobra.RangeArgs(6, 9),
+		Args:  cobra.RangeArgs(5, 8),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
@@ -67,7 +67,6 @@ func getCmdShareDocument(cdc *codec.Codec) *cobra.Command {
 						Uri:     args[3],
 						Version: args[4],
 					},
-					Proof: args[5],
 				},
 				Checksum: checksum,
 			}

--- a/x/docs/client/cli/tx.go
+++ b/x/docs/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	ctypes "github.com/commercionetwork/commercionetwork/x/common/types"
 	"github.com/commercionetwork/commercionetwork/x/docs/internal/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/x/auth"
@@ -47,16 +48,17 @@ func getCmdShareDocument(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			var contentUri, checksumValue, checksumAlgorithm string
+			var checksum *types.DocumentChecksum
+			var contentUri string
 			if len(args) > 6 {
 				contentUri = args[6]
-				checksumValue = args[7]
-				checksumAlgorithm = args[8]
+				checksum = &types.DocumentChecksum{
+					Value:     args[7],
+					Algorithm: args[8],
+				}
 			}
 
 			document := types.Document{
-				Sender:     sender,
-				Recipient:  recipient,
 				ContentUri: contentUri,
 				Uuid:       args[1],
 				Metadata: types.DocumentMetadata{
@@ -67,13 +69,10 @@ func getCmdShareDocument(cdc *codec.Codec) *cobra.Command {
 					},
 					Proof: args[5],
 				},
-				Checksum: types.DocumentChecksum{
-					Value:     checksumValue,
-					Algorithm: checksumAlgorithm,
-				},
+				Checksum: checksum,
 			}
 
-			msg := types.NewMsgShareDocument(document)
+			msg := types.NewMsgShareDocument(sender, ctypes.Addresses{recipient}, document)
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err

--- a/x/docs/genesis.go
+++ b/x/docs/genesis.go
@@ -48,10 +48,20 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
 
 	var usersData []UserDocumentsData
 	for _, user := range users {
+		sentDocs, err := keeper.GetUserSentDocuments(ctx, user)
+		if err != nil {
+			panic(err)
+		}
+
+		receivedDocs, err := keeper.GetUserReceivedDocuments(ctx, user)
+		if err != nil {
+			panic(err)
+		}
+
 		userData := UserDocumentsData{
 			User:              user,
-			SentDocuments:     keeper.GetUserSentDocuments(ctx, user),
-			ReceivedDocuments: keeper.GetUserReceivedDocuments(ctx, user),
+			SentDocuments:     sentDocs,
+			ReceivedDocuments: receivedDocs,
 			SentReceipts:      keeper.GetUserSentReceipts(ctx, user),
 			ReceivedReceipts:  keeper.GetUserReceivedReceipts(ctx, user),
 		}

--- a/x/docs/handler.go
+++ b/x/docs/handler.go
@@ -29,20 +29,20 @@ func NewHandler(keeper Keeper) sdk.Handler {
 func handleMsgShareDocument(ctx sdk.Context, keeper Keeper, msg MsgShareDocument) sdk.Result {
 
 	// The metadata schema type is being specified
-	if len(msg.Metadata.SchemaType) != 0 {
+	if len(msg.Document.Metadata.SchemaType) != 0 {
 
 		// Check its validity
-		if !keeper.IsMetadataSchemeTypeSupported(ctx, msg.Metadata.SchemaType) {
-			errMsg := fmt.Sprintf("Unsupported metadata schema: %s", msg.Metadata.SchemaType)
+		if !keeper.IsMetadataSchemeTypeSupported(ctx, msg.Document.Metadata.SchemaType) {
+			errMsg := fmt.Sprintf("Unsupported metadata schema: %s", msg.Document.Metadata.SchemaType)
 			return sdk.ErrUnknownRequest(errMsg).Result()
 		}
 
 		// Delete the custom data
-		msg.Metadata.Schema = nil
+		msg.Document.Metadata.Schema = nil
 	}
 
 	// Share the document
-	keeper.ShareDocument(ctx, types.Document(msg))
+	keeper.ShareDocument(ctx, msg.Sender, msg.Recipients, msg.Document)
 	return sdk.Result{}
 }
 

--- a/x/docs/handler.go
+++ b/x/docs/handler.go
@@ -2,6 +2,7 @@ package docs
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/commercionetwork/commercionetwork/x/docs/internal/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -29,7 +30,7 @@ func NewHandler(keeper Keeper) sdk.Handler {
 func handleMsgShareDocument(ctx sdk.Context, keeper Keeper, msg MsgShareDocument) sdk.Result {
 
 	// The metadata schema type is being specified
-	if len(msg.Document.Metadata.SchemaType) != 0 {
+	if len(strings.TrimSpace(msg.Document.Metadata.SchemaType)) != 0 {
 
 		// Check its validity
 		if !keeper.IsMetadataSchemeTypeSupported(ctx, msg.Document.Metadata.SchemaType) {

--- a/x/docs/handler_test.go
+++ b/x/docs/handler_test.go
@@ -97,8 +97,6 @@ func Test_handleMsgSendDocumentReceipt(t *testing.T) {
 func Test_handleMsgAddSupportedMetadataSchema_NotTrustedSigner(t *testing.T) {
 	_, ctx, k := SetupTestInput()
 	var handler = NewHandler(k)
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(MetadataSchemaProposersStoreKey))
 
 	msgAddSupportedMetadataSchema := MsgAddSupportedMetadataSchema{
 		Signer: TestingSender,

--- a/x/docs/handler_test.go
+++ b/x/docs/handler_test.go
@@ -5,8 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/commercionetwork/commercionetwork/x/docs/internal/keeper"
-	"github.com/commercionetwork/commercionetwork/x/docs/internal/types"
+	"github.com/commercionetwork/commercionetwork/x/common/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,32 +16,34 @@ import (
 // -----------------------------
 
 func Test_handleMsgShareDocument_CustomMetadataSpecs(t *testing.T) {
-	_, ctx, k := TestSetup()
+	_, ctx, k := SetupTestInput()
 	var handler = NewHandler(k)
 
-	msgShareDocument := MsgShareDocument(keeper.TestingDocument)
+	msgShareDocument := NewMsgShareDocument(TestingSender, types.Addresses{TestingRecipient}, TestingDocument)
 
 	res := handler(ctx, msgShareDocument)
 	require.True(t, res.IsOK())
 }
 
 func Test_handleMsgShareDocument_MetadataSchemeType_Supported(t *testing.T) {
-	_, ctx, k := TestSetup()
+	_, ctx, k := SetupTestInput()
 	var handler = NewHandler(k)
 
 	msgShareDocument := MsgShareDocument{
-		Sender:    keeper.TestingDocument.Sender,
-		Recipient: keeper.TestingDocument.Recipient,
-		Uuid:      keeper.TestingDocument.Uuid,
-		Metadata: types.DocumentMetadata{
-			ContentUri: keeper.TestingDocument.Metadata.ContentUri,
-			SchemaType: "metadata-schema",
-			Proof:      keeper.TestingDocument.Metadata.Proof,
+		Sender:     TestingSender,
+		Recipients: types.Addresses{TestingRecipient},
+		Document: Document{
+			Uuid: TestingDocument.Uuid,
+			Metadata: DocumentMetadata{
+				ContentUri: TestingDocument.Metadata.ContentUri,
+				SchemaType: "metadata-schema",
+				Proof:      TestingDocument.Metadata.Proof,
+			},
+			ContentUri: TestingDocument.ContentUri,
+			Checksum:   TestingDocument.Checksum,
 		},
-		ContentUri: keeper.TestingDocument.ContentUri,
-		Checksum:   keeper.TestingDocument.Checksum,
 	}
-	supportedSchema := types.MetadataSchema{
+	supportedSchema := MetadataSchema{
 		Type:      "metadata-schema",
 		SchemaUri: "https://example.com/schema",
 		Version:   "1.0.0",
@@ -54,19 +55,21 @@ func Test_handleMsgShareDocument_MetadataSchemeType_Supported(t *testing.T) {
 }
 
 func Test_handleMsgShareDocument_MetadataSchemeType_NotSupported(t *testing.T) {
-	_, ctx, k := TestSetup()
+	_, ctx, k := SetupTestInput()
 	var handler = NewHandler(k)
 	msgShareDocument := MsgShareDocument{
-		Sender:    keeper.TestingDocument.Sender,
-		Recipient: keeper.TestingDocument.Recipient,
-		Uuid:      keeper.TestingDocument.Uuid,
-		Metadata: types.DocumentMetadata{
-			ContentUri: keeper.TestingDocument.Metadata.ContentUri,
-			SchemaType: "non-existent-schema-type",
-			Proof:      keeper.TestingDocument.Metadata.Proof,
+		Sender:     TestingSender,
+		Recipients: types.Addresses{TestingRecipient},
+		Document: Document{
+			Uuid: TestingDocument.Uuid,
+			Metadata: DocumentMetadata{
+				ContentUri: TestingDocument.Metadata.ContentUri,
+				SchemaType: "non-existent-schema-type",
+				Proof:      TestingDocument.Metadata.Proof,
+			},
+			ContentUri: TestingDocument.ContentUri,
+			Checksum:   TestingDocument.Checksum,
 		},
-		ContentUri: keeper.TestingDocument.ContentUri,
-		Checksum:   keeper.TestingDocument.Checksum,
 	}
 
 	res := handler(ctx, msgShareDocument)
@@ -79,9 +82,9 @@ func Test_handleMsgShareDocument_MetadataSchemeType_NotSupported(t *testing.T) {
 // -----------------------------------
 
 func Test_handleMsgSendDocumentReceipt(t *testing.T) {
-	_, ctx, k := TestSetup()
+	_, ctx, k := SetupTestInput()
 	var handler = NewHandler(k)
-	msgSendDocumentReceipt := MsgSendDocumentReceipt(keeper.TestingDocumentReceipt)
+	msgSendDocumentReceipt := MsgSendDocumentReceipt(TestingDocumentReceipt)
 
 	res := handler(ctx, msgSendDocumentReceipt)
 	assert.True(t, res.IsOK())
@@ -92,14 +95,14 @@ func Test_handleMsgSendDocumentReceipt(t *testing.T) {
 // -------------------------------------------
 
 func Test_handleMsgAddSupportedMetadataSchema_NotTrustedSigner(t *testing.T) {
-	_, ctx, k := TestSetup()
+	_, ctx, k := SetupTestInput()
 	var handler = NewHandler(k)
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(types.MetadataSchemaProposersStoreKey))
+	store.Delete([]byte(MetadataSchemaProposersStoreKey))
 
 	msgAddSupportedMetadataSchema := MsgAddSupportedMetadataSchema{
-		Signer: keeper.TestingSender,
-		Schema: types.MetadataSchema{
+		Signer: TestingSender,
+		Schema: MetadataSchema{
 			Type:      "schema-type",
 			SchemaUri: "https://example.com/schema",
 			Version:   "1.0.0",
@@ -111,16 +114,16 @@ func Test_handleMsgAddSupportedMetadataSchema_NotTrustedSigner(t *testing.T) {
 }
 
 func Test_handleMsgAddSupportedMetadataSchema_TrustedSigner(t *testing.T) {
-	cdc, ctx, k := TestSetup()
+	cdc, ctx, k := SetupTestInput()
 	var handler = NewHandler(k)
-	signers := []sdk.AccAddress{keeper.TestingSender}
+	signers := []sdk.AccAddress{TestingSender}
 
 	store := ctx.KVStore(k.StoreKey)
-	store.Set([]byte(types.MetadataSchemaProposersStoreKey), cdc.MustMarshalBinaryBare(&signers))
+	store.Set([]byte(MetadataSchemaProposersStoreKey), cdc.MustMarshalBinaryBare(&signers))
 
 	msgAddSupportedMetadataSchema := MsgAddSupportedMetadataSchema{
-		Signer: keeper.TestingSender,
-		Schema: types.MetadataSchema{
+		Signer: TestingSender,
+		Schema: MetadataSchema{
 			Type:      "schema-type",
 			SchemaUri: "https://example.com/schema",
 			Version:   "1.0.0",
@@ -135,12 +138,12 @@ func Test_handleMsgAddSupportedMetadataSchema_TrustedSigner(t *testing.T) {
 // ------------------------------------------------
 
 func Test_handleMsgAddTrustedMetadataSchemaProposer_MissingGovernment(t *testing.T) {
-	_, ctx, k := TestSetup()
+	_, ctx, k := SetupTestInput()
 	var handler = NewHandler(k)
 
-	msgAddTrustedMetadataSchemaProposer := types.MsgAddTrustedMetadataSchemaProposer{
-		Proposer: keeper.TestingSender,
-		Signer:   keeper.TestingRecipient,
+	msgAddTrustedMetadataSchemaProposer := MsgAddTrustedMetadataSchemaProposer{
+		Proposer: TestingSender,
+		Signer:   TestingRecipient,
 	}
 	res := handler(ctx, msgAddTrustedMetadataSchemaProposer)
 	assert.False(t, res.IsOK())
@@ -148,13 +151,13 @@ func Test_handleMsgAddTrustedMetadataSchemaProposer_MissingGovernment(t *testing
 }
 
 func Test_handleMsgAddTrustedMetadataSchemaProposer_IncorrectSigner(t *testing.T) {
-	_, ctx, k := TestSetup()
+	_, ctx, k := SetupTestInput()
 	var handler = NewHandler(k)
-	_ = k.GovernmentKeeper.SetGovernmentAddress(ctx, keeper.TestingRecipient)
+	_ = k.GovernmentKeeper.SetGovernmentAddress(ctx, TestingRecipient)
 
-	msgAddTrustedMetadataSchemaProposer := types.MsgAddTrustedMetadataSchemaProposer{
-		Proposer: keeper.TestingSender,
-		Signer:   keeper.TestingSender,
+	msgAddTrustedMetadataSchemaProposer := MsgAddTrustedMetadataSchemaProposer{
+		Proposer: TestingSender,
+		Signer:   TestingSender,
 	}
 	res := handler(ctx, msgAddTrustedMetadataSchemaProposer)
 	assert.False(t, res.IsOK())
@@ -162,13 +165,13 @@ func Test_handleMsgAddTrustedMetadataSchemaProposer_IncorrectSigner(t *testing.T
 }
 
 func Test_handleMsgAddTrustedMetadataSchemaProposer_CorrectSigner(t *testing.T) {
-	_, ctx, k := TestSetup()
+	_, ctx, k := SetupTestInput()
 	var handler = NewHandler(k)
-	_ = k.GovernmentKeeper.SetGovernmentAddress(ctx, keeper.TestingRecipient)
+	_ = k.GovernmentKeeper.SetGovernmentAddress(ctx, TestingRecipient)
 
-	msgAddTrustedMetadataSchemaProposer := types.MsgAddTrustedMetadataSchemaProposer{
-		Proposer: keeper.TestingSender,
-		Signer:   keeper.TestingRecipient,
+	msgAddTrustedMetadataSchemaProposer := MsgAddTrustedMetadataSchemaProposer{
+		Proposer: TestingSender,
+		Signer:   TestingRecipient,
 	}
 	res := handler(ctx, msgAddTrustedMetadataSchemaProposer)
 	assert.True(t, res.IsOK())
@@ -179,7 +182,7 @@ func Test_handleMsgAddTrustedMetadataSchemaProposer_CorrectSigner(t *testing.T) 
 // -------------------
 
 func Test_invalidMsg(t *testing.T) {
-	_, ctx, k := TestSetup()
+	_, ctx, k := SetupTestInput()
 	var handler = NewHandler(k)
 	res := handler(ctx, sdk.NewTestMsg())
 	assert.False(t, res.IsOK())

--- a/x/docs/handler_test.go
+++ b/x/docs/handler_test.go
@@ -37,7 +37,6 @@ func Test_handleMsgShareDocument_MetadataSchemeType_Supported(t *testing.T) {
 			Metadata: DocumentMetadata{
 				ContentUri: TestingDocument.Metadata.ContentUri,
 				SchemaType: "metadata-schema",
-				Proof:      TestingDocument.Metadata.Proof,
 			},
 			ContentUri: TestingDocument.ContentUri,
 			Checksum:   TestingDocument.Checksum,
@@ -65,7 +64,6 @@ func Test_handleMsgShareDocument_MetadataSchemeType_NotSupported(t *testing.T) {
 			Metadata: DocumentMetadata{
 				ContentUri: TestingDocument.Metadata.ContentUri,
 				SchemaType: "non-existent-schema-type",
-				Proof:      TestingDocument.Metadata.Proof,
 			},
 			ContentUri: TestingDocument.ContentUri,
 			Checksum:   TestingDocument.Checksum,

--- a/x/docs/internal/keeper/keeper_test.go
+++ b/x/docs/internal/keeper/keeper_test.go
@@ -190,104 +190,145 @@ func TestKeeper_ShareDocument_EmptyLists(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	store := ctx.KVStore(k.StoreKey)
 
-	k.ShareDocument(ctx, TestingDocument)
+	err := k.ShareDocument(ctx, TestingSender, ctypes.Addresses{TestingRecipient}, TestingDocument)
+	assert.Nil(t, err)
 
-	sentDocsBz := store.Get([]byte(types.SentDocumentsPrefix + TestingSender.String()))
-	receivedDocsBz := store.Get([]byte(types.ReceivedDocumentsPrefix + TestingRecipient.String()))
+	docsBz := store.Get(k.getDocumentStoreKey(TestingDocument.Uuid))
+	sentDocsBz := store.Get(k.getSentDocumentsStoreKey(TestingSender))
+	receivedDocsBz := store.Get(k.getReceivedDocumentsStoreKey(TestingRecipient))
 
-	var sentDocs, receivedDocs types.Documents
+	var stored types.Document
+	cdc.MustUnmarshalBinaryBare(docsBz, &stored)
+	assert.Equal(t, stored, TestingDocument)
+
+	var sentDocs, receivedDocs types.DocumentIds
 	cdc.MustUnmarshalBinaryBare(sentDocsBz, &sentDocs)
 	cdc.MustUnmarshalBinaryBare(receivedDocsBz, &receivedDocs)
 
 	assert.Equal(t, 1, len(sentDocs))
-	assert.Contains(t, sentDocs, TestingDocument)
+	assert.Contains(t, sentDocs, TestingDocument.Uuid)
 
 	assert.Equal(t, 1, len(receivedDocs))
-	assert.Equal(t, sentDocs, receivedDocs)
+	assert.Contains(t, receivedDocs, TestingDocument.Uuid)
 }
 
 func TestKeeper_ShareDocument_ExistingDocument(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
-	documents := types.Documents{TestingDocument}
 	store := ctx.KVStore(k.StoreKey)
-	store.Set([]byte(types.SentDocumentsPrefix+TestingSender.String()), cdc.MustMarshalBinaryBare(&documents))
-	store.Set([]byte(types.ReceivedDocumentsPrefix+TestingRecipient.String()), cdc.MustMarshalBinaryBare(&documents))
 
-	k.ShareDocument(ctx, TestingDocument)
+	store.Set(k.getDocumentStoreKey(TestingDocument.Uuid), cdc.MustMarshalBinaryBare(TestingDocument))
 
-	sentDocsBz := store.Get([]byte(types.SentDocumentsPrefix + TestingSender.String()))
-	receivedDocsBz := store.Get([]byte(types.ReceivedDocumentsPrefix + TestingRecipient.String()))
+	documentsIds := types.DocumentIds{TestingDocument.Uuid}
+	store.Set(k.getSentDocumentsStoreKey(TestingSender), cdc.MustMarshalBinaryBare(&documentsIds))
+	store.Set(k.getReceivedDocumentsStoreKey(TestingRecipient), cdc.MustMarshalBinaryBare(&documentsIds))
 
-	var sentDocs, receivedDocs types.Documents
+	err := k.ShareDocument(ctx, TestingSender, ctypes.Addresses{TestingRecipient}, TestingDocument)
+	assert.NotNil(t, err)
+
+	sentDocsBz := store.Get(k.getSentDocumentsStoreKey(TestingSender))
+	receivedDocsBz := store.Get(k.getReceivedDocumentsStoreKey(TestingRecipient))
+
+	var sentDocs, receivedDocs types.DocumentIds
 	cdc.MustUnmarshalBinaryBare(sentDocsBz, &sentDocs)
 	cdc.MustUnmarshalBinaryBare(receivedDocsBz, &receivedDocs)
 
 	assert.Equal(t, 1, len(sentDocs))
-	assert.Contains(t, sentDocs, TestingDocument)
+	assert.Contains(t, sentDocs, TestingDocument.Uuid)
 
 	assert.Equal(t, 1, len(receivedDocs))
-	assert.Equal(t, sentDocs, receivedDocs)
+	assert.Contains(t, receivedDocs, TestingDocument.Uuid)
 }
 
-func TestKeeper_ShareDocument_SameInfoDifferentRecipient(t *testing.T) {
+func TestKeeper_ShareDocument_SameDocumentDifferentRecipient(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
-	documents := types.Documents{TestingDocument}
+	documentsIds := types.DocumentIds{TestingDocument.Uuid}
 
 	store := ctx.KVStore(k.StoreKey)
-	store.Set(
-		k.getSentDocumentsStoreKey(TestingDocument.Sender),
-		cdc.MustMarshalBinaryBare(&documents),
-	)
-	store.Set(
-		k.getReceivedDocumentsStoreKey(TestingDocument.Recipient),
-		cdc.MustMarshalBinaryBare(&documents),
-	)
+	store.Set(k.getSentDocumentsStoreKey(TestingSender), cdc.MustMarshalBinaryBare(&documentsIds))
+	store.Set(k.getReceivedDocumentsStoreKey(TestingRecipient), cdc.MustMarshalBinaryBare(&documentsIds))
 
 	newRecipient, _ := sdk.AccAddressFromBech32("cosmos1h2z8u9294gtqmxlrnlyfueqysng3krh009fum7")
 	newDocument := types.Document{
-		Sender:     TestingDocument.Sender,
-		Recipient:  newRecipient,
 		ContentUri: TestingDocument.ContentUri,
 		Metadata:   TestingDocument.Metadata,
 		Checksum:   TestingDocument.Checksum,
 	}
-	k.ShareDocument(ctx, newDocument)
+	err := k.ShareDocument(ctx, TestingSender, ctypes.Addresses{newRecipient}, newDocument)
+	assert.Nil(t, err)
 
-	sentDocsBz := store.Get(k.getSentDocumentsStoreKey(TestingDocument.Sender))
-	receivedDocsBz := store.Get(k.getReceivedDocumentsStoreKey(TestingDocument.Recipient))
+	sentDocsBz := store.Get(k.getSentDocumentsStoreKey(TestingSender))
+	receivedDocsBz := store.Get(k.getReceivedDocumentsStoreKey(TestingRecipient))
 	newReceivedDocsBz := store.Get(k.getReceivedDocumentsStoreKey(newRecipient))
 
-	var sentDocs, receivedDocs, newReceivedDocs types.Documents
+	var sentDocs, receivedDocs, newReceivedDocs types.DocumentIds
 	cdc.MustUnmarshalBinaryBare(sentDocsBz, &sentDocs)
 	cdc.MustUnmarshalBinaryBare(receivedDocsBz, &receivedDocs)
 	cdc.MustUnmarshalBinaryBare(newReceivedDocsBz, &newReceivedDocs)
 
-	assert.Equal(t, 2, len(sentDocs))
-	assert.Contains(t, sentDocs, TestingDocument)
-	assert.Contains(t, sentDocs, newDocument)
+	assert.Equal(t, 1, len(sentDocs))
+	assert.Contains(t, sentDocs, TestingDocument.Uuid)
 
 	assert.Equal(t, 1, len(receivedDocs))
-	assert.Contains(t, receivedDocs, TestingDocument)
+	assert.Contains(t, receivedDocs, TestingDocument.Uuid)
 
 	assert.Equal(t, 1, len(newReceivedDocs))
-	assert.Contains(t, newReceivedDocs, newDocument)
+	assert.Contains(t, newReceivedDocs, newDocument.Uuid)
+}
+
+func TestKeeper_ShareDocument_SameDocumentDifferentUuid(t *testing.T) {
+	cdc, ctx, k := SetupTestInput()
+	documentsIds := types.DocumentIds{TestingDocument.Uuid}
+
+	store := ctx.KVStore(k.StoreKey)
+	store.Set(k.getSentDocumentsStoreKey(TestingSender), cdc.MustMarshalBinaryBare(&documentsIds))
+	store.Set(k.getReceivedDocumentsStoreKey(TestingRecipient), cdc.MustMarshalBinaryBare(&documentsIds))
+
+	newDocument := types.Document{
+		Uuid:       TestingDocument.Uuid + "new",
+		ContentUri: TestingDocument.ContentUri,
+		Metadata:   TestingDocument.Metadata,
+		Checksum:   TestingDocument.Checksum,
+	}
+	err := k.ShareDocument(ctx, TestingSender, ctypes.Addresses{TestingRecipient}, newDocument)
+	assert.Nil(t, err)
+
+	sentDocsBz := store.Get(k.getSentDocumentsStoreKey(TestingSender))
+	receivedDocsBz := store.Get(k.getReceivedDocumentsStoreKey(TestingRecipient))
+
+	var sentDocs, receivedDocs types.DocumentIds
+	cdc.MustUnmarshalBinaryBare(sentDocsBz, &sentDocs)
+	cdc.MustUnmarshalBinaryBare(receivedDocsBz, &receivedDocs)
+
+	assert.Equal(t, 2, len(sentDocs))
+	assert.Contains(t, sentDocs, TestingDocument.Uuid)
+
+	assert.Equal(t, 2, len(receivedDocs))
+	assert.Contains(t, receivedDocs, TestingDocument.Uuid)
 }
 
 func TestKeeper_GetUserReceivedDocuments_EmptyList(t *testing.T) {
 	_, ctx, k := SetupTestInput()
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(types.ReceivedDocumentsPrefix + TestingRecipient.String()))
+	store.Delete(k.getReceivedDocumentsStoreKey(TestingRecipient))
 
-	receivedDocs := k.GetUserReceivedDocuments(ctx, TestingDocument.Sender)
+	receivedDocs, err := k.GetUserReceivedDocuments(ctx, TestingRecipient)
+	assert.Nil(t, err)
+
 	assert.Equal(t, 0, len(receivedDocs))
 }
 
 func TestKeeper_GetUserReceivedDocuments_NonEmptyList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
-	documents := types.Documents{TestingDocument}
 	store := ctx.KVStore(k.StoreKey)
-	store.Set([]byte(types.ReceivedDocumentsPrefix+TestingRecipient.String()), cdc.MustMarshalBinaryBare(&documents))
-	receivedDocs := k.GetUserReceivedDocuments(ctx, TestingRecipient)
+
+	documents := types.Documents{TestingDocument}
+	documentIds := types.DocumentIds{TestingDocument.Uuid}
+
+	store.Set(k.getDocumentStoreKey(TestingDocument.Uuid), cdc.MustMarshalBinaryBare(TestingDocument))
+	store.Set(k.getReceivedDocumentsStoreKey(TestingRecipient), cdc.MustMarshalBinaryBare(&documentIds))
+
+	receivedDocs, err := k.GetUserReceivedDocuments(ctx, TestingRecipient)
+	assert.Nil(t, err)
 
 	assert.Equal(t, 1, len(receivedDocs))
 	assert.Equal(t, documents, receivedDocs)
@@ -295,20 +336,27 @@ func TestKeeper_GetUserReceivedDocuments_NonEmptyList(t *testing.T) {
 
 func TestKeeper_GetUserSentDocuments_EmptyList(t *testing.T) {
 	_, ctx, k := SetupTestInput()
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(types.SentDocumentsPrefix + TestingSender.String()))
 
-	sentDocuments := k.GetUserSentDocuments(ctx, TestingDocument.Sender)
+	store := ctx.KVStore(k.StoreKey)
+	store.Delete(k.getSentDocumentsStoreKey(TestingSender))
+
+	sentDocuments, err := k.GetUserSentDocuments(ctx, TestingSender)
+	assert.Nil(t, err)
+
 	assert.Equal(t, 0, len(sentDocuments))
 }
 
 func TestKeeper_GetUserSentDocuments_NonEmptyList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
-	documents := types.Documents{TestingDocument}
 	store := ctx.KVStore(k.StoreKey)
-	store.Set([]byte(types.SentDocumentsPrefix+TestingSender.String()), cdc.MustMarshalBinaryBare(&documents))
 
-	sentDocuments := k.GetUserSentDocuments(ctx, TestingSender)
+	documents := types.Documents{TestingDocument}
+	documentIds := types.DocumentIds{TestingDocument.Uuid}
+	store.Set(k.getDocumentStoreKey(TestingDocument.Uuid), cdc.MustMarshalBinaryBare(TestingDocument))
+	store.Set(k.getSentDocumentsStoreKey(TestingSender), cdc.MustMarshalBinaryBare(&documentIds))
+
+	sentDocuments, err := k.GetUserSentDocuments(ctx, TestingSender)
+	assert.Nil(t, err)
 
 	assert.Equal(t, 1, len(sentDocuments))
 	assert.Equal(t, documents, sentDocuments)
@@ -417,14 +465,14 @@ func TestKeeper_GetUserReceivedReceiptsForDocument_UuidFound(t *testing.T) {
 
 func TestKeeper_GetUsersSet_FilledSet(t *testing.T) {
 	_, ctx, k := SetupTestInput()
-	k.ShareDocument(ctx, TestingDocument)
+	_ = k.ShareDocument(ctx, TestingSender, ctypes.Addresses{TestingRecipient}, TestingDocument)
 	k.SendDocumentReceipt(ctx, TestingDocumentReceipt)
 
 	users, err := k.GetUsersSet(ctx)
 
 	assert.Nil(t, err)
-	assert.Contains(t, users, TestingDocument.Sender)
-	assert.Contains(t, users, TestingDocument.Recipient)
+	assert.Contains(t, users, TestingSender)
+	assert.Contains(t, users, TestingRecipient)
 	assert.Contains(t, users, TestingDocumentReceipt.Sender)
 	assert.Contains(t, users, TestingDocumentReceipt.Recipient)
 }
@@ -440,16 +488,16 @@ func TestKeeper_GetUsersSet_EmptySet(t *testing.T) {
 func TestKeeper_SetUserDocuments(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getSentDocumentsStoreKey(TestingDocument.Sender))
-	store.Delete(k.getReceivedDocumentsStoreKey(TestingDocument.Recipient))
+	store.Delete(k.getSentDocumentsStoreKey(TestingSender))
+	store.Delete(k.getReceivedDocumentsStoreKey(TestingRecipient))
 
 	documents := types.Documents{TestingDocument}
 
-	k.SetUserDocuments(ctx, TestingDocument.Sender, documents, types.Documents{})
-	k.SetUserDocuments(ctx, TestingDocument.Recipient, types.Documents{}, documents)
+	k.SetUserDocuments(ctx, TestingSender, documents, types.Documents{})
+	k.SetUserDocuments(ctx, TestingRecipient, types.Documents{}, documents)
 
-	sentBz := store.Get(k.getSentDocumentsStoreKey(TestingDocument.Sender))
-	receivedBz := store.Get(k.getReceivedDocumentsStoreKey(TestingDocument.Recipient))
+	sentBz := store.Get(k.getSentDocumentsStoreKey(TestingSender))
+	receivedBz := store.Get(k.getReceivedDocumentsStoreKey(TestingRecipient))
 
 	var sentDocuments, receivedDocuments types.Documents
 	cdc.MustUnmarshalBinaryBare(sentBz, &sentDocuments)

--- a/x/docs/internal/keeper/keeper_test.go
+++ b/x/docs/internal/keeper/keeper_test.go
@@ -17,7 +17,6 @@ func TestKeeper_AddSupportedMetadataScheme_EmptyList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	//Setup the store
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(types.SupportedMetadataSchemesStoreKey))
 
 	schema := types.MetadataSchema{Type: "schema", SchemaUri: "https://example.com/schema", Version: "1.0.0"}
 	k.AddSupportedMetadataScheme(ctx, schema)
@@ -54,8 +53,6 @@ func TestKeeper_AddSupportedMetadataScheme_ExistingList(t *testing.T) {
 
 func TestKeeper_IsMetadataSchemeTypeSupported_EmptyList(t *testing.T) {
 	_, ctx, k := SetupTestInput()
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(types.SupportedMetadataSchemesStoreKey))
 
 	assert.False(t, k.IsMetadataSchemeTypeSupported(ctx, "schema"))
 	assert.False(t, k.IsMetadataSchemeTypeSupported(ctx, "schema2"))
@@ -78,8 +75,6 @@ func TestKeeper_IsMetadataSchemeTypeSupported_ExistingList(t *testing.T) {
 
 func TestKeeper_GetSupportedMetadataSchemes_EmptyList(t *testing.T) {
 	_, ctx, k := SetupTestInput()
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(types.SupportedMetadataSchemesStoreKey))
 
 	result := k.GetSupportedMetadataSchemes(ctx)
 
@@ -107,7 +102,6 @@ func TestKeeper_GetSupportedMetadataSchemes_ExistingList(t *testing.T) {
 func TestKeeper_AddTrustedSchemaProposer_EmptyList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(types.MetadataSchemaProposersStoreKey))
 
 	k.AddTrustedSchemaProposer(ctx, TestingSender)
 
@@ -140,8 +134,6 @@ func TestKeeper_AddTrustedSchemaProposer_ExistingList(t *testing.T) {
 
 func TestKeeper_IsTrustedSchemaProposer_EmptyList(t *testing.T) {
 	_, ctx, k := SetupTestInput()
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(types.MetadataSchemaProposersStoreKey))
 
 	assert.False(t, k.IsTrustedSchemaProposer(ctx, TestingSender))
 	assert.False(t, k.IsTrustedSchemaProposer(ctx, TestingSender2))
@@ -161,8 +153,6 @@ func TestKeeper_IsTrustedSchemaProposerExistingList(t *testing.T) {
 
 func TestKeeper_GetTrustedSchemaProposers_EmptyList(t *testing.T) {
 	_, ctx, k := SetupTestInput()
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(types.MetadataSchemaProposersStoreKey))
 
 	stored := k.GetTrustedSchemaProposers(ctx)
 
@@ -308,8 +298,6 @@ func TestKeeper_ShareDocument_SameDocumentDifferentUuid(t *testing.T) {
 
 func TestKeeper_GetUserReceivedDocuments_EmptyList(t *testing.T) {
 	_, ctx, k := SetupTestInput()
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getReceivedDocumentsStoreKey(TestingRecipient))
 
 	receivedDocs, err := k.GetUserReceivedDocuments(ctx, TestingRecipient)
 	assert.Nil(t, err)
@@ -336,9 +324,6 @@ func TestKeeper_GetUserReceivedDocuments_NonEmptyList(t *testing.T) {
 
 func TestKeeper_GetUserSentDocuments_EmptyList(t *testing.T) {
 	_, ctx, k := SetupTestInput()
-
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getSentDocumentsStoreKey(TestingSender))
 
 	sentDocuments, err := k.GetUserSentDocuments(ctx, TestingSender)
 	assert.Nil(t, err)
@@ -369,7 +354,6 @@ func TestKeeper_GetUserSentDocuments_NonEmptyList(t *testing.T) {
 func TestKeeper_SendDocumentReceipt_EmptyList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getSentReceiptsStoreKey(TestingDocumentReceipt.Sender))
 
 	k.SendDocumentReceipt(ctx, TestingDocumentReceipt)
 
@@ -403,8 +387,6 @@ func TestKeeper_SendDocumentReceipt_ExistingReceipt(t *testing.T) {
 
 func TestKeeper_GetUserReceivedReceipts_EmptyList(t *testing.T) {
 	_, ctx, k := SetupTestInput()
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient))
 
 	receipts := k.GetUserReceivedReceipts(ctx, TestingDocumentReceipt.Recipient)
 
@@ -488,8 +470,6 @@ func TestKeeper_GetUsersSet_EmptySet(t *testing.T) {
 func TestKeeper_SetUserDocuments(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getSentDocumentsStoreKey(TestingSender))
-	store.Delete(k.getReceivedDocumentsStoreKey(TestingRecipient))
 
 	documents := types.Documents{TestingDocument}
 
@@ -510,8 +490,6 @@ func TestKeeper_SetUserDocuments(t *testing.T) {
 func TestKeeper_SetUserReceipts(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getSentReceiptsStoreKey(TestingDocumentReceipt.Sender))
-	store.Delete(k.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient))
 
 	receipts := types.DocumentReceipts{TestingDocumentReceipt}
 

--- a/x/docs/internal/keeper/querier.go
+++ b/x/docs/internal/keeper/querier.go
@@ -40,7 +40,11 @@ func queryGetReceivedDocuments(ctx sdk.Context, path []string, keeper Keeper) ([
 	addr := path[0]
 	address, _ := sdk.AccAddressFromBech32(addr)
 
-	receivedResult := keeper.GetUserReceivedDocuments(ctx, address)
+	receivedResult, err := keeper.GetUserReceivedDocuments(ctx, address)
+	if err != nil {
+		return nil, sdk.ErrUnknownRequest(err.Error())
+	}
+
 	if receivedResult == nil {
 		receivedResult = make([]types.Document, 0)
 	}
@@ -57,7 +61,11 @@ func queryGetSentDocuments(ctx sdk.Context, path []string, keeper Keeper) ([]byt
 	addr := path[0]
 	address, _ := sdk.AccAddressFromBech32(addr)
 
-	receivedResult := keeper.GetUserSentDocuments(ctx, address)
+	receivedResult, err := keeper.GetUserSentDocuments(ctx, address)
+	if err != nil {
+		return nil, sdk.ErrUnknownRequest(err.Error())
+	}
+
 	if receivedResult == nil {
 		receivedResult = make([]types.Document, 0)
 	}

--- a/x/docs/internal/keeper/querier_test.go
+++ b/x/docs/internal/keeper/querier_test.go
@@ -19,9 +19,6 @@ var documents = types.Documents{TestingDocument}
 func Test_queryGetReceivedDocuments_EmptyList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	var querier = NewQuerier(k)
-	//Setup the store
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getReceivedDocumentsStoreKey(TestingRecipient))
 
 	path := []string{types.QueryReceivedDocuments, TestingRecipient.String()}
 
@@ -57,9 +54,6 @@ func Test_queryGetReceivedDocuments_ExistingList(t *testing.T) {
 func Test_queryGetSentDocuments_EmptyList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	var querier = NewQuerier(k)
-	//Setup the store
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getSentDocumentsStoreKey(TestingSender))
 
 	path := []string{types.QuerySentDocuments, TestingSender.String()}
 
@@ -98,9 +92,6 @@ func Test_queryGetSentDocuments_ExistingList(t *testing.T) {
 func Test_queryGetReceivedDocsReceipts_EmptyList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	var querier = NewQuerier(k)
-	//Setup the store
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient))
 
 	path := []string{types.QueryReceivedReceipts, TestingDocumentReceipt.Recipient.String(), ""}
 
@@ -118,7 +109,6 @@ func Test_queryGetReceivedDocsReceipts_ExistingList(t *testing.T) {
 	var querier = NewQuerier(k)
 	//Setup the store
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient))
 
 	var stored = types.DocumentReceipts{TestingDocumentReceipt}
 	store.Set(
@@ -142,7 +132,6 @@ func Test_queryGetReceivedDocsReceipts_WithDocUuid(t *testing.T) {
 	var querier = NewQuerier(k)
 	//Setup the store
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getReceivedReceiptsStoreKey(TestingDocumentReceipt.Recipient))
 
 	var stored = types.DocumentReceipts{TestingDocumentReceipt}
 	store.Set(
@@ -165,9 +154,6 @@ func Test_queryGetReceivedDocsReceipts_WithDocUuid(t *testing.T) {
 func Test_queryGetSentDocsReceipts_EmptyList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	var querier = NewQuerier(k)
-	//Setup the store
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getSentReceiptsStoreKey(TestingDocumentReceipt.Sender))
 
 	path := []string{types.QuerySentReceipts, TestingDocumentReceipt.Sender.String()}
 
@@ -207,9 +193,6 @@ func Test_queryGetSentDocsReceipts_ExistingList(t *testing.T) {
 func Test_querySupportedMetadataSchemes_EmptyList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	var querier = NewQuerier(k)
-	//Setup the store
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(types.SupportedMetadataSchemesStoreKey))
 
 	path := []string{types.QuerySupportedMetadataSchemes}
 
@@ -249,9 +232,6 @@ func Test_querySupportedMetadataSchemes_ExistingList(t *testing.T) {
 func Test_queryTrustedMetadataProposers_EmptyList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	var querier = NewQuerier(k)
-	//Setup the store
-	store := ctx.KVStore(k.StoreKey)
-	store.Delete([]byte(types.MetadataSchemaProposersStoreKey))
 
 	path := []string{types.QueryTrustedMetadataProposers}
 

--- a/x/docs/internal/keeper/querier_test.go
+++ b/x/docs/internal/keeper/querier_test.go
@@ -21,9 +21,9 @@ func Test_queryGetReceivedDocuments_EmptyList(t *testing.T) {
 	var querier = NewQuerier(k)
 	//Setup the store
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getReceivedDocumentsStoreKey(TestingDocument.Recipient))
+	store.Delete(k.getReceivedDocumentsStoreKey(TestingRecipient))
 
-	path := []string{types.QueryReceivedDocuments, TestingDocument.Recipient.String()}
+	path := []string{types.QueryReceivedDocuments, TestingRecipient.String()}
 
 	var actual types.Documents
 	actualBz, _ := querier(ctx, path, request)
@@ -36,15 +36,15 @@ func Test_queryGetReceivedDocuments_EmptyList(t *testing.T) {
 func Test_queryGetReceivedDocuments_ExistingList(t *testing.T) {
 	cdc, ctx, k := SetupTestInput()
 	var querier = NewQuerier(k)
+
 	// Setup the store
 	metadataStore := ctx.KVStore(k.StoreKey)
-	metadataStore.Set(
-		k.getReceivedDocumentsStoreKey(TestingDocument.Recipient),
-		cdc.MustMarshalBinaryBare(&documents),
-	)
+	documentIds := types.DocumentIds{TestingDocument.Uuid}
+	metadataStore.Set(k.getReceivedDocumentsStoreKey(TestingRecipient), cdc.MustMarshalBinaryBare(&documentIds))
+	metadataStore.Set(k.getDocumentStoreKey(TestingDocument.Uuid), cdc.MustMarshalBinaryBare(TestingDocument))
 
 	// Compose the path
-	path := []string{types.QueryReceivedDocuments, TestingDocument.Recipient.String()}
+	path := []string{types.QueryReceivedDocuments, TestingRecipient.String()}
 
 	// Get the returned documents
 	var actual types.Documents
@@ -59,9 +59,9 @@ func Test_queryGetSentDocuments_EmptyList(t *testing.T) {
 	var querier = NewQuerier(k)
 	//Setup the store
 	store := ctx.KVStore(k.StoreKey)
-	store.Delete(k.getSentDocumentsStoreKey(TestingDocument.Sender))
+	store.Delete(k.getSentDocumentsStoreKey(TestingSender))
 
-	path := []string{types.QuerySentDocuments, TestingDocument.Sender.String()}
+	path := []string{types.QuerySentDocuments, TestingSender.String()}
 
 	var actual types.Documents
 	actualBz, _ := querier(ctx, path, request)
@@ -76,13 +76,12 @@ func Test_queryGetSentDocuments_ExistingList(t *testing.T) {
 	var querier = NewQuerier(k)
 	//Setup the store
 	metadataStore := ctx.KVStore(k.StoreKey)
-	metadataStore.Set(
-		k.getSentDocumentsStoreKey(TestingDocument.Sender),
-		cdc.MustMarshalBinaryBare(&documents),
-	)
+	documentIds := types.DocumentIds{TestingDocument.Uuid}
+	metadataStore.Set(k.getSentDocumentsStoreKey(TestingSender), cdc.MustMarshalBinaryBare(&documentIds))
+	metadataStore.Set(k.getDocumentStoreKey(TestingDocument.Uuid), cdc.MustMarshalBinaryBare(TestingDocument))
 
 	// Compose the path
-	path := []string{types.QuerySentDocuments, TestingDocument.Sender.String()}
+	path := []string{types.QuerySentDocuments, TestingSender.String()}
 
 	// Get the returned documents
 	var actual types.Documents

--- a/x/docs/internal/keeper/test_commons.go
+++ b/x/docs/internal/keeper/test_commons.go
@@ -63,7 +63,6 @@ func testCodec() *codec.Codec {
 var TestingSender, _ = sdk.AccAddressFromBech32("cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0")
 var TestingSender2, _ = sdk.AccAddressFromBech32("cosmos1nynns8ex9fq6sjjfj8k79ymkdz4sqth06xexae")
 var TestingRecipient, _ = sdk.AccAddressFromBech32("cosmos1tupew4x3rhh0lpqha9wvzmzxjr4e37mfy3qefm")
-var TestingRecipient2, _ = sdk.AccAddressFromBech32("cosmos10yj4fsyt76c5g8jgltj90zwfvn0aplama685ma")
 
 var TestingDocument = types.Document{
 	ContentUri: "https://example.com/document",
@@ -73,7 +72,6 @@ var TestingDocument = types.Document{
 			Uri:     "https://example.com/document/metadata/schema",
 			Version: "1.0.0",
 		},
-		Proof: "73666c68676c7366676c7366676c6a6873666c6a6768",
 	},
 	Checksum: &types.DocumentChecksum{
 		Value:     "93dfcaf3d923ec47edb8580667473987",

--- a/x/docs/internal/keeper/test_commons.go
+++ b/x/docs/internal/keeper/test_commons.go
@@ -63,10 +63,9 @@ func testCodec() *codec.Codec {
 var TestingSender, _ = sdk.AccAddressFromBech32("cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0")
 var TestingSender2, _ = sdk.AccAddressFromBech32("cosmos1nynns8ex9fq6sjjfj8k79ymkdz4sqth06xexae")
 var TestingRecipient, _ = sdk.AccAddressFromBech32("cosmos1tupew4x3rhh0lpqha9wvzmzxjr4e37mfy3qefm")
+var TestingRecipient2, _ = sdk.AccAddressFromBech32("cosmos10yj4fsyt76c5g8jgltj90zwfvn0aplama685ma")
 
 var TestingDocument = types.Document{
-	Sender:     TestingSender,
-	Recipient:  TestingRecipient,
 	ContentUri: "https://example.com/document",
 	Metadata: types.DocumentMetadata{
 		ContentUri: "",
@@ -76,7 +75,7 @@ var TestingDocument = types.Document{
 		},
 		Proof: "73666c68676c7366676c7366676c6a6873666c6a6768",
 	},
-	Checksum: types.DocumentChecksum{
+	Checksum: &types.DocumentChecksum{
 		Value:     "93dfcaf3d923ec47edb8580667473987",
 		Algorithm: "md5",
 	},

--- a/x/docs/internal/types/document.go
+++ b/x/docs/internal/types/document.go
@@ -19,20 +19,26 @@ type Document struct {
 }
 
 // TODO: Test
-func (doc Document) Equals(doc2 Document) bool {
-	if (doc.Checksum == nil || doc2.Checksum == nil) && doc.Checksum != doc2.Checksum {
-		return false
+func (doc Document) Equals(other Document) bool {
+	validContent := doc.Uuid == other.Uuid &&
+		doc.ContentUri == other.ContentUri &&
+		doc.Metadata.Equals(other.Metadata)
+
+	var validChecksum bool
+	if doc.Checksum != nil && other.Checksum != nil {
+		validChecksum = doc.Checksum.Equals(*other.Checksum)
+	} else {
+		validChecksum = doc.Checksum == other.Checksum
 	}
 
-	if (doc.EncryptionData == nil || doc2.EncryptionData == nil) && doc.EncryptionData != doc2.EncryptionData {
-		return false
+	var validEncryptionData bool
+	if doc.EncryptionData != nil && other.EncryptionData != nil {
+		validEncryptionData = doc.EncryptionData.Equals(*other.EncryptionData)
+	} else {
+		validEncryptionData = doc.EncryptionData == other.EncryptionData
 	}
 
-	return doc.Uuid == doc2.Uuid &&
-		doc.ContentUri == doc2.ContentUri &&
-		doc.Metadata.Equals(doc2.Metadata) &&
-		doc.Checksum.Equals(*doc2.Checksum) &&
-		doc.EncryptionData.Equals(*doc2.EncryptionData)
+	return validContent && validChecksum && validEncryptionData
 }
 
 func validateUuid(uuid string) bool {

--- a/x/docs/internal/types/document.go
+++ b/x/docs/internal/types/document.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	"regexp"
+	"strings"
 )
 
 // Document contains the generic information about a single document which has been sent from a user to another user.
@@ -43,7 +44,7 @@ func (doc Document) Validate() error {
 	if !validateUuid(doc.Uuid) {
 		return errors.New("invalid document UUID")
 	}
-	if len(doc.ContentUri) == 0 {
+	if len(strings.TrimSpace(doc.ContentUri)) == 0 {
 		return errors.New("document content Uri can't be empty")
 	}
 

--- a/x/docs/internal/types/document_checksum.go
+++ b/x/docs/internal/types/document_checksum.go
@@ -30,10 +30,10 @@ func (checksum DocumentChecksum) Equals(other DocumentChecksum) bool {
 
 // Validate returns an error if there is something wrong inside this DocumentChecksum
 func (checksum DocumentChecksum) Validate() error {
-	if len(checksum.Value) == 0 {
+	if len(strings.TrimSpace(checksum.Value)) == 0 {
 		return errors.New("checksum value can't be empty")
 	}
-	if len(checksum.Algorithm) == 0 {
+	if len(strings.TrimSpace(checksum.Algorithm)) == 0 {
 		return errors.New("checksum algorithm can't be empty")
 	}
 
@@ -51,7 +51,7 @@ func (checksum DocumentChecksum) Validate() error {
 	}
 
 	// Check the validity of the checksum value
-	if len(checksum.Value) != length {
+	if len(strings.TrimSpace(checksum.Value)) != length {
 		return errors.New(fmt.Sprintf("invalid checksum length for algorithm %s", algorithm))
 	}
 

--- a/x/docs/internal/types/document_checksum.go
+++ b/x/docs/internal/types/document_checksum.go
@@ -7,6 +7,15 @@ import (
 	"strings"
 )
 
+var algorithms = map[string]int{
+	"md5":     32,
+	"sha-1":   40,
+	"sha-224": 56,
+	"sha-256": 64,
+	"sha-384": 96,
+	"sha-512": 128,
+}
+
 // DocumentChecksum represents the information related to the checksum of a document, if any
 type DocumentChecksum struct {
 	Value     string `json:"value"`

--- a/x/docs/internal/types/document_checksum.go
+++ b/x/docs/internal/types/document_checksum.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// DocumentChecksum represents the information related to the checksum of a document, if any
+type DocumentChecksum struct {
+	Value     string `json:"value"`
+	Algorithm string `json:"algorithm"`
+}
+
+// Equals returns true iff this DocumentChecksum and other have the same contents
+func (checksum DocumentChecksum) Equals(other DocumentChecksum) bool {
+	return checksum.Value == other.Value &&
+		checksum.Algorithm == other.Algorithm
+}
+
+// Validate returns an error if there is something wrong inside this DocumentChecksum
+func (checksum DocumentChecksum) Validate() error {
+	if len(checksum.Value) == 0 {
+		return errors.New("checksum value can't be empty")
+	}
+	if len(checksum.Algorithm) == 0 {
+		return errors.New("checksum algorithm can't be empty")
+	}
+
+	_, err := hex.DecodeString(checksum.Value)
+	if err != nil {
+		return errors.New("invalid checksum value (must be hex)")
+	}
+
+	algorithm := strings.ToLower(checksum.Algorithm)
+
+	// Check that the algorithm is valid
+	length, ok := algorithms[algorithm]
+	if !ok {
+		return errors.New(fmt.Sprintf("invalid algorithm type %s", algorithm))
+	}
+
+	// Check the validity of the checksum value
+	if len(checksum.Value) != length {
+		return errors.New(fmt.Sprintf("invalid checksum length for algorithm %s", algorithm))
+	}
+
+	return nil
+}

--- a/x/docs/internal/types/document_checksum_test.go
+++ b/x/docs/internal/types/document_checksum_test.go
@@ -6,11 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// --------------------------
-// --- Checksum validation
-// --------------------------
-
-func TestValidateChecksum_validChecksum(t *testing.T) {
+func TestDocumentCheckSum_Validate_ValidChecksum(t *testing.T) {
 	var checksumList = map[string]string{
 		"md5":     "0cc175b9c0f1b6a831c399e269772661",
 		"sha-1":   "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8",
@@ -27,7 +23,7 @@ func TestValidateChecksum_validChecksum(t *testing.T) {
 	}
 }
 
-func TestValidateChecksum_emptyValue(t *testing.T) {
+func TestDocumentCheckSum_Validate_EmptyValue(t *testing.T) {
 	invalidChecksum := DocumentChecksum{
 		Value:     "",
 		Algorithm: "md5",
@@ -37,7 +33,7 @@ func TestValidateChecksum_emptyValue(t *testing.T) {
 	assert.NotNil(t, actual)
 }
 
-func TestValidateChecksum_emptyAlgorithm(t *testing.T) {
+func TestDocumentCheckSum_Validate_EmptyAlgorithm(t *testing.T) {
 	invalidChecksum := DocumentChecksum{
 		Value:     "48656c6c6f20476f7068657221234567",
 		Algorithm: "",
@@ -47,7 +43,7 @@ func TestValidateChecksum_emptyAlgorithm(t *testing.T) {
 	assert.NotNil(t, actual)
 }
 
-func TestValidateChecksum_invalidHexValue(t *testing.T) {
+func TestDocumentCheckSum_Validate_InvalidHexValue(t *testing.T) {
 	invalidChecksum := DocumentChecksum{
 		Value:     "qr54g7srg5674fsg4sfg",
 		Algorithm: "md5",
@@ -57,7 +53,7 @@ func TestValidateChecksum_invalidHexValue(t *testing.T) {
 	assert.NotNil(t, actual)
 }
 
-func TestValidateChecksum_invalidAlgorithmType(t *testing.T) {
+func TestDocumentCheckSum_Validate_InvalidAlgorithmType(t *testing.T) {
 	invalidChecksum := DocumentChecksum{
 		Value:     "48656c6c6f20476f7068657221234567",
 		Algorithm: "md6",
@@ -67,7 +63,7 @@ func TestValidateChecksum_invalidAlgorithmType(t *testing.T) {
 	assert.NotNil(t, actual)
 }
 
-func TestValidateChecksum_invalidChecksumLengths(t *testing.T) {
+func TestDocumentCheckSum_Validate_InvalidChecksumLengths(t *testing.T) {
 	var checksumList = map[string]string{
 		"md5":     "0cc175bc0f1b6a831c399e269772661",
 		"sha-1":   "86f7e437faa5a7fce15dddcb9eaeaea377667b8",

--- a/x/docs/internal/types/document_checksum_test.go
+++ b/x/docs/internal/types/document_checksum_test.go
@@ -1,0 +1,85 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// --------------------------
+// --- Checksum validation
+// --------------------------
+
+func TestValidateChecksum_validChecksum(t *testing.T) {
+	var checksumList = map[string]string{
+		"md5":     "0cc175b9c0f1b6a831c399e269772661",
+		"sha-1":   "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8",
+		"sha-224": "abd37534c7d9a2efb9465de931cd7055ffdb8879563ae98078d6d6d5",
+		"sha-256": "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+		"sha-384": "54a59b9f22b0b80880d8427e548b7c23abd873486e1f035dce9cd697e85175033caa88e6d57bc35efae0b5afd3145f31",
+		"sha-512": "1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75",
+	}
+
+	for key, value := range checksumList {
+		checksum := DocumentChecksum{Algorithm: key, Value: value}
+		actual := checksum.Validate()
+		assert.Nil(t, actual)
+	}
+}
+
+func TestValidateChecksum_emptyValue(t *testing.T) {
+	invalidChecksum := DocumentChecksum{
+		Value:     "",
+		Algorithm: "md5",
+	}
+
+	actual := invalidChecksum.Validate()
+	assert.NotNil(t, actual)
+}
+
+func TestValidateChecksum_emptyAlgorithm(t *testing.T) {
+	invalidChecksum := DocumentChecksum{
+		Value:     "48656c6c6f20476f7068657221234567",
+		Algorithm: "",
+	}
+
+	actual := invalidChecksum.Validate()
+	assert.NotNil(t, actual)
+}
+
+func TestValidateChecksum_invalidHexValue(t *testing.T) {
+	invalidChecksum := DocumentChecksum{
+		Value:     "qr54g7srg5674fsg4sfg",
+		Algorithm: "md5",
+	}
+
+	actual := invalidChecksum.Validate()
+	assert.NotNil(t, actual)
+}
+
+func TestValidateChecksum_invalidAlgorithmType(t *testing.T) {
+	invalidChecksum := DocumentChecksum{
+		Value:     "48656c6c6f20476f7068657221234567",
+		Algorithm: "md6",
+	}
+
+	actual := invalidChecksum.Validate()
+	assert.NotNil(t, actual)
+}
+
+func TestValidateChecksum_invalidChecksumLengths(t *testing.T) {
+	var checksumList = map[string]string{
+		"md5":     "0cc175bc0f1b6a831c399e269772661",
+		"sha-1":   "86f7e437faa5a7fce15dddcb9eaeaea377667b8",
+		"sha-224": "abd37534c7d9a2efb946de931cd7055ffdb8879563ae98078d6d6d5",
+		"sha-256": "ca978112ca1bbdcafac21b39a23dc4da786eff8147c4e72b9807785afee48bb",
+		"sha-384": "54a59b9f22b0b80880d427e548b7c23abd873486e1f035dce9cd697e85175033caa88e6d57bc35efae0b5afd3145f31",
+		"sha-512": "1f40fc92da24169475099ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75",
+	}
+
+	for key, value := range checksumList {
+		checksum := DocumentChecksum{Algorithm: key, Value: value}
+		actual := checksum.Validate()
+		assert.NotNil(t, actual)
+	}
+}

--- a/x/docs/internal/types/document_encryption_data.go
+++ b/x/docs/internal/types/document_encryption_data.go
@@ -12,7 +12,6 @@ type DocumentEncryptionData struct {
 }
 
 // Equals returns true iff this dat and other contain the same data
-// TODO: Test this
 func (data DocumentEncryptionData) Equals(other DocumentEncryptionData) bool {
 	if len(data.Keys) != len(other.Keys) {
 		return false

--- a/x/docs/internal/types/document_encryption_data.go
+++ b/x/docs/internal/types/document_encryption_data.go
@@ -14,10 +14,18 @@ type DocumentEncryptionData struct {
 // Equals returns true iff this dat and other contain the same data
 // TODO: Test this
 func (data DocumentEncryptionData) Equals(other DocumentEncryptionData) bool {
+	if len(data.Keys) != len(other.Keys) {
+		return false
+	}
+
 	for index, _ := range data.Keys {
 		if !data.Keys[index].Equals(other.Keys[index]) {
 			return false
 		}
+	}
+
+	if len(data.EncryptedData) != len(other.EncryptedData) {
+		return false
 	}
 
 	for index, _ := range data.EncryptedData {
@@ -31,8 +39,11 @@ func (data DocumentEncryptionData) Equals(other DocumentEncryptionData) bool {
 
 // Validate tries to validate all the data contained inside the given
 // DocumentEncryptionData and returns an error if something is wrong
-// TODO: Test this
 func (data DocumentEncryptionData) Validate() error {
+
+	if len(data.Keys) == 0 {
+		return errors.New("encryption data keys cannot be empty")
+	}
 
 	// Validate the keys
 	for _, key := range data.Keys {

--- a/x/docs/internal/types/document_encryption_data.go
+++ b/x/docs/internal/types/document_encryption_data.go
@@ -1,0 +1,52 @@
+package types
+
+import (
+	"errors"
+)
+
+// DocumentEncryptionData contains the data that are related to the way
+// that a document's contents or other data have been encrypted
+type DocumentEncryptionData struct {
+	Keys          []DocumentEncryptionKey `json:"keys"`           // contains the keys used to encrypt the data
+	EncryptedData []string                `json:"encrypted_data"` // contains the list of data that have been encrypted
+}
+
+// Equals returns true iff this dat and other contain the same data
+// TODO: Test this
+func (data DocumentEncryptionData) Equals(other DocumentEncryptionData) bool {
+	for index, _ := range data.Keys {
+		if !data.Keys[index].Equals(other.Keys[index]) {
+			return false
+		}
+	}
+
+	for index, _ := range data.EncryptedData {
+		if data.EncryptedData[index] != other.EncryptedData[index] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Validate tries to validate all the data contained inside the given
+// DocumentEncryptionData and returns an error if something is wrong
+// TODO: Test this
+func (data DocumentEncryptionData) Validate() error {
+
+	// Validate the keys
+	for _, key := range data.Keys {
+		if err := key.Validate(); err != nil {
+			return err
+		}
+	}
+
+	// Validate the encrypted data
+	for _, data := range data.EncryptedData {
+		if data != "content" && data != "content_uri" && data != "metadata.content_uri" && data != "metadata.schema.uri" {
+			return errors.New("encrypted data not supported")
+		}
+	}
+
+	return nil
+}

--- a/x/docs/internal/types/document_encryption_data_test.go
+++ b/x/docs/internal/types/document_encryption_data_test.go
@@ -7,10 +7,7 @@ import (
 )
 
 var data = DocumentEncryptionData{
-	Keys: []DocumentEncryptionKey{
-		{Recipient: recipient, Value: "6F7468657276616C7565", Encoding: "hex"},
-		{Recipient: sender, Value: "b3RoZXIgdmFsdWU=", Encoding: "base64"},
-	},
+	Keys:          []DocumentEncryptionKey{{Recipient: recipient, Value: "6F7468657276616C7565"}},
 	EncryptedData: []string{"content", "content_uri", "metadata.content_uri", "metadata.schema.uri"},
 }
 
@@ -23,12 +20,15 @@ func TestDocumentEncryptionData_Equals(t *testing.T) {
 }
 
 func TestDocumentEncryptionData_Equals_DifferentKeysLength(t *testing.T) {
-	other := DocumentEncryptionData{Keys: []DocumentEncryptionKey{data.Keys[0]}, EncryptedData: data.EncryptedData}
+	other := DocumentEncryptionData{Keys: []DocumentEncryptionKey{}, EncryptedData: data.EncryptedData}
 	assert.False(t, data.Equals(other))
 }
 
 func TestDocumentEncryptionData_Equals_DifferentKeys(t *testing.T) {
-	other := DocumentEncryptionData{Keys: []DocumentEncryptionKey{data.Keys[1], data.Keys[0]}, EncryptedData: data.EncryptedData}
+	other := DocumentEncryptionData{
+		Keys:          []DocumentEncryptionKey{{Recipient: sender, Value: data.Keys[0].Value}},
+		EncryptedData: data.EncryptedData,
+	}
 	assert.False(t, data.Equals(other))
 }
 
@@ -61,7 +61,7 @@ func TestDocumentEncryptionData_Validate_EmptyKeys(t *testing.T) {
 func TestDocumentEncryptionData_Validate_InvalidKey(t *testing.T) {
 	invalid := DocumentEncryptionData{
 		Keys: []DocumentEncryptionKey{
-			{Recipient: nil, Value: "", Encoding: ""},
+			{Recipient: nil, Value: ""},
 		},
 		EncryptedData: data.EncryptedData,
 	}

--- a/x/docs/internal/types/document_encryption_data_test.go
+++ b/x/docs/internal/types/document_encryption_data_test.go
@@ -1,0 +1,79 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var data = DocumentEncryptionData{
+	Keys: []DocumentEncryptionKey{
+		{Recipient: recipient, Value: "6F7468657276616C7565", Encoding: "hex"},
+		{Recipient: sender, Value: "b3RoZXIgdmFsdWU=", Encoding: "base64"},
+	},
+	EncryptedData: []string{"content", "content_uri", "metadata.content_uri", "metadata.schema.uri"},
+}
+
+// --------------
+// --- Equals
+// --------------
+
+func TestDocumentEncryptionData_Equals(t *testing.T) {
+	assert.True(t, data.Equals(data))
+}
+
+func TestDocumentEncryptionData_Equals_DifferentKeysLength(t *testing.T) {
+	other := DocumentEncryptionData{Keys: []DocumentEncryptionKey{data.Keys[0]}, EncryptedData: data.EncryptedData}
+	assert.False(t, data.Equals(other))
+}
+
+func TestDocumentEncryptionData_Equals_DifferentKeys(t *testing.T) {
+	other := DocumentEncryptionData{Keys: []DocumentEncryptionKey{data.Keys[1], data.Keys[0]}, EncryptedData: data.EncryptedData}
+	assert.False(t, data.Equals(other))
+}
+
+func TestDocumentEncryptionData_Equals_DifferentEncryptedDataLength(t *testing.T) {
+	other := DocumentEncryptionData{Keys: data.Keys, EncryptedData: []string{"content"}}
+	assert.False(t, data.Equals(other))
+}
+
+func TestDocumentEncryptionData_Equals_DifferentEncryptedData(t *testing.T) {
+	other := DocumentEncryptionData{Keys: data.Keys, EncryptedData: []string{"metadata.schema.uri", "content_uri", "content", "metadata.content_uri"}}
+	assert.False(t, data.Equals(other))
+}
+
+// ---------------
+// --- Validate
+// ---------------
+
+func TestDocumentEncryptionData_Validate(t *testing.T) {
+	assert.Nil(t, data.Validate())
+}
+
+func TestDocumentEncryptionData_Validate_EmptyKeys(t *testing.T) {
+	invalid := DocumentEncryptionData{Keys: nil, EncryptedData: data.EncryptedData}
+	err := invalid.Validate()
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "encryption data keys cannot be empty", err.Error())
+}
+
+func TestDocumentEncryptionData_Validate_InvalidKey(t *testing.T) {
+	invalid := DocumentEncryptionData{
+		Keys: []DocumentEncryptionKey{
+			{Recipient: nil, Value: "", Encoding: ""},
+		},
+		EncryptedData: data.EncryptedData,
+	}
+	err := invalid.Validate()
+
+	assert.NotNil(t, err)
+}
+
+func TestDocumentEncryptionData_Validate_InvalidEncryptedData(t *testing.T) {
+	invalid := DocumentEncryptionData{Keys: data.Keys, EncryptedData: []string{"invalid.data"}}
+	err := invalid.Validate()
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "encrypted data not supported", err.Error())
+}

--- a/x/docs/internal/types/document_encryption_key.go
+++ b/x/docs/internal/types/document_encryption_key.go
@@ -19,11 +19,10 @@ type DocumentEncryptionKey struct {
 }
 
 // Equals returns true iff this dat and other contain the same data
-// TODO: Test this
 func (key DocumentEncryptionKey) Equals(other DocumentEncryptionKey) bool {
 	return key.Recipient.Equals(other.Recipient) &&
-		key.Value != other.Value &&
-		key.Encoding != other.Encoding
+		key.Value == other.Value &&
+		key.Encoding == other.Encoding
 }
 
 // Validate tries to validate all the data contained inside the given
@@ -34,12 +33,12 @@ func (key DocumentEncryptionKey) Validate() error {
 		return errors.New(fmt.Sprintf("invalid address %s", key.Recipient.String()))
 	}
 
-	if len(key.Value) == 0 {
-		return errors.New("encryption key value cannot be null")
+	if len(strings.TrimSpace(key.Value)) == 0 {
+		return errors.New("encryption key value cannot be empty")
 	}
 
-	if len(key.Encoding) == 0 {
-		return errors.New("encryption key encoding cannot be null")
+	if len(strings.TrimSpace(key.Encoding)) == 0 {
+		return errors.New("encryption key encoding cannot be empty")
 	}
 
 	encoding := strings.ToLower(key.Encoding)
@@ -58,8 +57,6 @@ func (key DocumentEncryptionKey) Validate() error {
 			return err
 		}
 	}
-
-	// TODO: Validate the value base on the encoding
 
 	return nil
 }

--- a/x/docs/internal/types/document_encryption_key.go
+++ b/x/docs/internal/types/document_encryption_key.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -15,14 +14,12 @@ import (
 type DocumentEncryptionKey struct {
 	Recipient sdk.AccAddress `json:"recipient"` // Recipient that should use this data
 	Value     string         `json:"value"`     // Value of the key that should be used. This is encrypted with the recipient's public key
-	Encoding  string         `json:"encoding"`  // Encoding used to write the above value
 }
 
 // Equals returns true iff this dat and other contain the same data
 func (key DocumentEncryptionKey) Equals(other DocumentEncryptionKey) bool {
 	return key.Recipient.Equals(other.Recipient) &&
-		key.Value == other.Value &&
-		key.Encoding == other.Encoding
+		key.Value == other.Value
 }
 
 // Validate tries to validate all the data contained inside the given
@@ -36,25 +33,8 @@ func (key DocumentEncryptionKey) Validate() error {
 		return errors.New("encryption key value cannot be empty")
 	}
 
-	if len(strings.TrimSpace(key.Encoding)) == 0 {
-		return errors.New("encryption key encoding cannot be empty")
-	}
-
-	encoding := strings.ToLower(key.Encoding)
-	if encoding != "base64" && encoding != "hex" {
-		return errors.New("encryption key encoding method unknown")
-	}
-
-	if encoding == "hex" {
-		if _, err := hex.DecodeString(key.Value); err != nil {
-			return err
-		}
-	}
-
-	if encoding == "base64" {
-		if _, err := base64.StdEncoding.DecodeString(key.Value); err != nil {
-			return err
-		}
+	if _, err := hex.DecodeString(key.Value); err != nil {
+		return errors.New("invalid encryption key value (must be hex)")
 	}
 
 	return nil

--- a/x/docs/internal/types/document_encryption_key.go
+++ b/x/docs/internal/types/document_encryption_key.go
@@ -27,7 +27,6 @@ func (key DocumentEncryptionKey) Equals(other DocumentEncryptionKey) bool {
 
 // Validate tries to validate all the data contained inside the given
 // DocumentEncryptionKey and returns an error if something bad occurs
-// TODO: Test this
 func (key DocumentEncryptionKey) Validate() error {
 	if key.Recipient.Empty() {
 		return errors.New(fmt.Sprintf("invalid address %s", key.Recipient.String()))

--- a/x/docs/internal/types/document_encryption_key_test.go
+++ b/x/docs/internal/types/document_encryption_key_test.go
@@ -9,7 +9,6 @@ import (
 var key = DocumentEncryptionKey{
 	Recipient: recipient,
 	Value:     "76616C7565",
-	Encoding:  "hex",
 }
 
 // --------------
@@ -24,7 +23,6 @@ func TestDocumentEncryptionKey_Equals_DifferentRecipient(t *testing.T) {
 	var other = DocumentEncryptionKey{
 		Recipient: sender,
 		Value:     key.Value,
-		Encoding:  key.Encoding,
 	}
 	assert.False(t, key.Equals(other))
 }
@@ -33,7 +31,6 @@ func TestDocumentEncryptionKey_Equals_DifferentValue(t *testing.T) {
 	var other = DocumentEncryptionKey{
 		Recipient: key.Recipient,
 		Value:     "6F7468657276616C7565",
-		Encoding:  key.Encoding,
 	}
 	assert.False(t, key.Equals(other))
 }
@@ -41,8 +38,7 @@ func TestDocumentEncryptionKey_Equals_DifferentValue(t *testing.T) {
 func TestDocumentEncryptionKey_Equals_DifferentEncoding(t *testing.T) {
 	var other = DocumentEncryptionKey{
 		Recipient: key.Recipient,
-		Value:     key.Value,
-		Encoding:  key.Encoding + "difference",
+		Value:     key.Value + "difference",
 	}
 	assert.False(t, key.Equals(other))
 }
@@ -56,41 +52,17 @@ func TestDocumentEncryptionKey_Validate(t *testing.T) {
 }
 
 func TestDocumentEncryptionKey_Validate_EmptyValue(t *testing.T) {
-	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: "   ", Encoding: key.Encoding}
+	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: "   "}
 	err := key.Validate()
 
 	assert.NotNil(t, err)
 	assert.Equal(t, "encryption key value cannot be empty", err.Error())
 }
 
-func TestDocumentEncryptionKey_Validate_EmptyEncoding(t *testing.T) {
-	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: key.Encoding, Encoding: "   "}
-	err := key.Validate()
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "encryption key encoding cannot be empty", err.Error())
-}
-
-func TestDocumentEncryptionKey_Validate_InvalidEncoding(t *testing.T) {
-	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: key.Encoding, Encoding: "faslgjfsdlgj"}
-	err := key.Validate()
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "encryption key encoding method unknown", err.Error())
-}
-
 func TestDocumentEncryptionKey_Validate_InvalidHex(t *testing.T) {
-	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: "^&*(^*(&*", Encoding: "hex"}
+	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: "^&*(^*(&*"}
 	err := key.Validate()
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "hex")
-}
-
-func TestDocumentEncryptionKey_Validate_InvalidBase64(t *testing.T) {
-	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: "^&*(^*(&*", Encoding: "base64"}
-	err := key.Validate()
-
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "base64")
 }

--- a/x/docs/internal/types/document_encryption_key_test.go
+++ b/x/docs/internal/types/document_encryption_key_test.go
@@ -1,0 +1,96 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var key = DocumentEncryptionKey{
+	Recipient: recipient,
+	Value:     "76616C7565",
+	Encoding:  "hex",
+}
+
+// --------------
+// --- Equals
+// --------------
+
+func TestDocumentEncryptionKey_Equals(t *testing.T) {
+	assert.True(t, key.Equals(key))
+}
+
+func TestDocumentEncryptionKey_Equals_DifferentRecipient(t *testing.T) {
+	var other = DocumentEncryptionKey{
+		Recipient: sender,
+		Value:     key.Value,
+		Encoding:  key.Encoding,
+	}
+	assert.False(t, key.Equals(other))
+}
+
+func TestDocumentEncryptionKey_Equals_DifferentValue(t *testing.T) {
+	var other = DocumentEncryptionKey{
+		Recipient: key.Recipient,
+		Value:     "6F7468657276616C7565",
+		Encoding:  key.Encoding,
+	}
+	assert.False(t, key.Equals(other))
+}
+
+func TestDocumentEncryptionKey_Equals_DifferentEncoding(t *testing.T) {
+	var other = DocumentEncryptionKey{
+		Recipient: key.Recipient,
+		Value:     key.Value,
+		Encoding:  key.Encoding + "difference",
+	}
+	assert.False(t, key.Equals(other))
+}
+
+// ---------------
+// --- Validate
+// ---------------
+
+func TestDocumentEncryptionKey_Validate(t *testing.T) {
+	assert.Nil(t, key.Validate())
+}
+
+func TestDocumentEncryptionKey_Validate_EmptyValue(t *testing.T) {
+	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: "   ", Encoding: key.Encoding}
+	err := key.Validate()
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "encryption key value cannot be empty", err.Error())
+}
+
+func TestDocumentEncryptionKey_Validate_EmptyEncoding(t *testing.T) {
+	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: key.Encoding, Encoding: "   "}
+	err := key.Validate()
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "encryption key encoding cannot be empty", err.Error())
+}
+
+func TestDocumentEncryptionKey_Validate_InvalidEncoding(t *testing.T) {
+	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: key.Encoding, Encoding: "faslgjfsdlgj"}
+	err := key.Validate()
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "encryption key encoding method unknown", err.Error())
+}
+
+func TestDocumentEncryptionKey_Validate_InvalidHex(t *testing.T) {
+	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: "^&*(^*(&*", Encoding: "hex"}
+	err := key.Validate()
+
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "hex")
+}
+
+func TestDocumentEncryptionKey_Validate_InvalidBase64(t *testing.T) {
+	key := DocumentEncryptionKey{Recipient: key.Recipient, Value: "^&*(^*(&*", Encoding: "base64"}
+	err := key.Validate()
+
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "base64")
+}

--- a/x/docs/internal/types/document_enryption_key.go
+++ b/x/docs/internal/types/document_enryption_key.go
@@ -1,0 +1,65 @@
+package types
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// DocumentEncryptionKey contains the data related to a specific encryption key
+// used to encrypt some document's data when sending it to a specific recipient
+type DocumentEncryptionKey struct {
+	Recipient sdk.AccAddress `json:"recipient"` // Recipient that should use this data
+	Value     string         `json:"value"`     // Value of the key that should be used. This is encrypted with the recipient's public key
+	Encoding  string         `json:"encoding"`  // Encoding used to write the above value
+}
+
+// Equals returns true iff this dat and other contain the same data
+// TODO: Test this
+func (key DocumentEncryptionKey) Equals(other DocumentEncryptionKey) bool {
+	return key.Recipient.Equals(other.Recipient) &&
+		key.Value != other.Value &&
+		key.Encoding != other.Encoding
+}
+
+// Validate tries to validate all the data contained inside the given
+// DocumentEncryptionKey and returns an error if something bad occurs
+// TODO: Test this
+func (key DocumentEncryptionKey) Validate() error {
+	if key.Recipient.Empty() {
+		return errors.New(fmt.Sprintf("invalid address %s", key.Recipient.String()))
+	}
+
+	if len(key.Value) == 0 {
+		return errors.New("encryption key value cannot be null")
+	}
+
+	if len(key.Encoding) == 0 {
+		return errors.New("encryption key encoding cannot be null")
+	}
+
+	encoding := strings.ToLower(key.Encoding)
+	if encoding != "base64" && encoding != "hex" {
+		return errors.New("encryption key encoding method unknown")
+	}
+
+	if encoding == "hex" {
+		if _, err := hex.DecodeString(key.Value); err != nil {
+			return err
+		}
+	}
+
+	if encoding == "base64" {
+		if _, err := base64.StdEncoding.DecodeString(key.Value); err != nil {
+			return err
+		}
+	}
+
+	// TODO: Validate the value base on the encoding
+
+	return nil
+}

--- a/x/docs/internal/types/document_id.go
+++ b/x/docs/internal/types/document_id.go
@@ -5,7 +5,6 @@ type DocumentIds []string
 
 // AppendIfMissing allows to add to this list of documentIds
 // the given id, if it isn't already present
-// TODO: Test this
 func (documentIds DocumentIds) AppendIfMissing(id string) DocumentIds {
 	for _, ele := range documentIds {
 		if ele == id {

--- a/x/docs/internal/types/document_id.go
+++ b/x/docs/internal/types/document_id.go
@@ -1,0 +1,16 @@
+package types
+
+// DocumentIds represents a list of documents' UUIDs
+type DocumentIds []string
+
+// AppendIfMissing allows to add to this list of documentIds
+// the given id, if it isn't already present
+// TODO: Test this
+func (documentIds DocumentIds) AppendIfMissing(id string) DocumentIds {
+	for _, ele := range documentIds {
+		if ele == id {
+			return documentIds
+		}
+	}
+	return append(documentIds, id)
+}

--- a/x/docs/internal/types/document_metadata.go
+++ b/x/docs/internal/types/document_metadata.go
@@ -1,0 +1,68 @@
+package types
+
+import (
+	"errors"
+)
+
+// DocumentMetadataSchema represents the information about the schema that should be used in order to
+// validate the metadata associated with a document.
+type DocumentMetadataSchema struct {
+	Uri     string `json:"uri"`
+	Version string `json:"version"`
+}
+
+func (metaSchema DocumentMetadataSchema) Equals(metSchema2 DocumentMetadataSchema) bool {
+	return metaSchema.Uri == metSchema2.Uri &&
+		metaSchema.Version == metSchema2.Version
+}
+
+// DocumentMetadata represents the information about the metadata associated to a document
+type DocumentMetadata struct {
+	ContentUri string                  `json:"content_uri"`
+	SchemaType string                  `json:"schema_type"` // Optional - Either this or schema must be defined
+	Schema     *DocumentMetadataSchema `json:"schema"`      // Optional - Either this or schema_type must be defined
+	Proof      string                  `json:"proof"`
+}
+
+// Equals returns true iff this metadata and other contain the same data
+// TODO: Test this
+func (metadata DocumentMetadata) Equals(other DocumentMetadata) bool {
+	if metadata.Schema == nil && other.Schema == nil {
+		return true
+	}
+
+	if metadata.Schema == nil || other.Schema == nil {
+		return false
+	}
+
+	return metadata.ContentUri == other.ContentUri &&
+		metadata.Proof == other.Proof &&
+		metadata.Schema.Equals(*other.Schema)
+}
+
+// Validate tries to validate all the data contained inside the given
+// DocumentMetadata and returns an error if something is wrong
+// TODO: Test this
+func (metadata DocumentMetadata) Validate() error {
+	if len(metadata.ContentUri) == 0 {
+		return errors.New("metadataSchema content URI can't be empty")
+	}
+
+	if (metadata.Schema == nil) && len(metadata.SchemaType) == 0 {
+		return errors.New("either schema or schema_type must be defined")
+	}
+
+	if metadata.Schema != nil {
+		if len(metadata.Schema.Uri) == 0 {
+			return errors.New("schema URI can't be empty")
+		}
+		if len(metadata.Schema.Version) == 0 {
+			return errors.New("schema version can't be empty")
+		}
+	}
+
+	if len(metadata.Proof) == 0 {
+		return errors.New("computation proof can't be empty")
+	}
+	return nil
+}

--- a/x/docs/internal/types/document_metadata.go
+++ b/x/docs/internal/types/document_metadata.go
@@ -22,12 +22,11 @@ type DocumentMetadata struct {
 	ContentUri string                  `json:"content_uri"`
 	SchemaType string                  `json:"schema_type"` // Optional - Either this or schema must be defined
 	Schema     *DocumentMetadataSchema `json:"schema"`      // Optional - Either this or schema_type must be defined
-	Proof      string                  `json:"proof"`
 }
 
 // Equals returns true iff this metadata and other contain the same data
 func (metadata DocumentMetadata) Equals(other DocumentMetadata) bool {
-	if metadata.ContentUri != other.ContentUri || metadata.Proof != other.Proof {
+	if metadata.ContentUri != other.ContentUri {
 		return false
 	}
 
@@ -56,10 +55,6 @@ func (metadata DocumentMetadata) Validate() error {
 		if len(strings.TrimSpace(metadata.Schema.Version)) == 0 {
 			return errors.New("metadata.schema.version can't be empty")
 		}
-	}
-
-	if len(strings.TrimSpace(metadata.Proof)) == 0 {
-		return errors.New("metadata.proof can't be empty")
 	}
 	return nil
 }

--- a/x/docs/internal/types/document_metadata.go
+++ b/x/docs/internal/types/document_metadata.go
@@ -41,7 +41,7 @@ func (metadata DocumentMetadata) Equals(other DocumentMetadata) bool {
 // Validate tries to validate all the data contained inside the given
 // DocumentMetadata and returns an error if something is wrong
 func (metadata DocumentMetadata) Validate() error {
-	if len(metadata.ContentUri) == 0 {
+	if len(strings.TrimSpace(metadata.ContentUri)) == 0 {
 		return errors.New("metadata.content_uri can't be empty")
 	}
 

--- a/x/docs/internal/types/document_metadata.go
+++ b/x/docs/internal/types/document_metadata.go
@@ -50,15 +50,15 @@ func (metadata DocumentMetadata) Validate() error {
 	}
 
 	if metadata.Schema != nil {
-		if len(metadata.Schema.Uri) == 0 {
+		if len(strings.TrimSpace(metadata.Schema.Uri)) == 0 {
 			return errors.New("metadata.schema.uri can't be empty")
 		}
-		if len(metadata.Schema.Version) == 0 {
+		if len(strings.TrimSpace(metadata.Schema.Version)) == 0 {
 			return errors.New("metadata.schema.version can't be empty")
 		}
 	}
 
-	if len(metadata.Proof) == 0 {
+	if len(strings.TrimSpace(metadata.Proof)) == 0 {
 		return errors.New("metadata.proof can't be empty")
 	}
 	return nil

--- a/x/docs/internal/types/document_metadata.go
+++ b/x/docs/internal/types/document_metadata.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"strings"
 )
 
 // DocumentMetadataSchema represents the information about the schema that should be used in order to
@@ -25,44 +26,40 @@ type DocumentMetadata struct {
 }
 
 // Equals returns true iff this metadata and other contain the same data
-// TODO: Test this
 func (metadata DocumentMetadata) Equals(other DocumentMetadata) bool {
-	if metadata.Schema == nil && other.Schema == nil {
-		return true
-	}
-
-	if metadata.Schema == nil || other.Schema == nil {
+	if metadata.ContentUri != other.ContentUri || metadata.Proof != other.Proof {
 		return false
 	}
 
-	return metadata.ContentUri == other.ContentUri &&
-		metadata.Proof == other.Proof &&
-		metadata.Schema.Equals(*other.Schema)
+	if metadata.Schema != nil && other.Schema != nil {
+		return metadata.Schema.Equals(*other.Schema)
+	}
+
+	return metadata.Schema == other.Schema
 }
 
 // Validate tries to validate all the data contained inside the given
 // DocumentMetadata and returns an error if something is wrong
-// TODO: Test this
 func (metadata DocumentMetadata) Validate() error {
 	if len(metadata.ContentUri) == 0 {
-		return errors.New("metadataSchema content URI can't be empty")
+		return errors.New("metadata.content_uri can't be empty")
 	}
 
-	if (metadata.Schema == nil) && len(metadata.SchemaType) == 0 {
-		return errors.New("either schema or schema_type must be defined")
+	if (metadata.Schema == nil) && len(strings.TrimSpace(metadata.SchemaType)) == 0 {
+		return errors.New("either metadata.schema or metadata.schema_type must be defined")
 	}
 
 	if metadata.Schema != nil {
 		if len(metadata.Schema.Uri) == 0 {
-			return errors.New("schema URI can't be empty")
+			return errors.New("metadata.schema.uri can't be empty")
 		}
 		if len(metadata.Schema.Version) == 0 {
-			return errors.New("schema version can't be empty")
+			return errors.New("metadata.schema.version can't be empty")
 		}
 	}
 
 	if len(metadata.Proof) == 0 {
-		return errors.New("computation proof can't be empty")
+		return errors.New("metadata.proof can't be empty")
 	}
 	return nil
 }

--- a/x/docs/internal/types/document_metadata_test.go
+++ b/x/docs/internal/types/document_metadata_test.go
@@ -63,7 +63,7 @@ func TestDocumentMetadata_Validate(t *testing.T) {
 
 func TestDocumentMetadata_Validate_EmptyContentUri(t *testing.T) {
 	invalidDocumentMetadata := DocumentMetadata{
-		ContentUri: "",
+		ContentUri: "   ",
 		Schema: &DocumentMetadataSchema{
 			Uri:     "http://www.contentUri.com",
 			Version: "test",

--- a/x/docs/internal/types/document_metadata_test.go
+++ b/x/docs/internal/types/document_metadata_test.go
@@ -6,11 +6,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// -------------------------
-// --- MetadataSchema validation
-// -------------------------
+func TestDocumentMetadata_Equals(t *testing.T) {
+	metadata := DocumentMetadata{
+		ContentUri: "http://example.com/metadata",
+		Schema: &DocumentMetadataSchema{
+			Uri:     "https://example.com/metadata/schema",
+			Version: "1.0.0",
+		},
+		Proof: "123",
+	}
+	assert.True(t, metadata.Equals(metadata))
+}
 
-func TestValidateDocMetadata_valid(t *testing.T) {
+func TestDocumentMetadata_Equals_DifferentContents(t *testing.T) {
+	metadata := DocumentMetadata{ContentUri: "http://example.com/metadata", Proof: "123"}
+
+	other := DocumentMetadata{ContentUri: "https://example.com", Proof: metadata.Proof}
+	assert.False(t, metadata.Equals(other))
+
+	other = DocumentMetadata{ContentUri: metadata.ContentUri, Proof: "1234"}
+	assert.False(t, metadata.Equals(other))
+}
+
+func TestDocumentMetadata_Equals_DifferentSchema(t *testing.T) {
+	metadata := DocumentMetadata{ContentUri: "http://example.com/metadata", Proof: "123"}
+
+	other := DocumentMetadata{
+		ContentUri: metadata.ContentUri,
+		SchemaType: metadata.SchemaType,
+		Schema: &DocumentMetadataSchema{
+			Uri:     "https://example.com/metadata/schema",
+			Version: "1.0.0",
+		},
+		Proof: metadata.Proof,
+	}
+	assert.False(t, metadata.Equals(other))
+}
+
+// ---------------
+// --- Validate
+// ---------------
+
+func TestDocumentMetadata_Validate(t *testing.T) {
 	validDocumentMetadata := DocumentMetadata{
 		ContentUri: "http://www.contentUri.com",
 		Schema: &DocumentMetadataSchema{
@@ -24,7 +61,7 @@ func TestValidateDocMetadata_valid(t *testing.T) {
 	assert.Nil(t, actual)
 }
 
-func TestValidateDocMetadata_emptyContentUri(t *testing.T) {
+func TestDocumentMetadata_Validate_EmptyContentUri(t *testing.T) {
 	invalidDocumentMetadata := DocumentMetadata{
 		ContentUri: "",
 		Schema: &DocumentMetadataSchema{
@@ -34,11 +71,25 @@ func TestValidateDocMetadata_emptyContentUri(t *testing.T) {
 		Proof: "proof",
 	}
 
-	actual := invalidDocumentMetadata.Validate()
-	assert.NotNil(t, actual)
+	err := invalidDocumentMetadata.Validate()
+	assert.NotNil(t, err)
+	assert.Equal(t, "metadata.content_uri can't be empty", err.Error())
 }
 
-func TestValidateDocMetadata_emptySchemaUri(t *testing.T) {
+func TestDocumentMetadata_Validate_EmptyMetadataInfo(t *testing.T) {
+	invalidDocumentMetadata := DocumentMetadata{
+		ContentUri: "https://example.com/metadata",
+		Schema:     nil,
+		SchemaType: "",
+		Proof:      "proof",
+	}
+
+	err := invalidDocumentMetadata.Validate()
+	assert.NotNil(t, err)
+	assert.Equal(t, "either metadata.schema or metadata.schema_type must be defined", err.Error())
+}
+
+func TestDocumentMetadata_Validate_EmptySchemaUri(t *testing.T) {
 	invalidDocumentMetadata := DocumentMetadata{
 		ContentUri: "http://www.contentUri.com",
 		Schema: &DocumentMetadataSchema{
@@ -48,11 +99,12 @@ func TestValidateDocMetadata_emptySchemaUri(t *testing.T) {
 		Proof: "proof",
 	}
 
-	actual := invalidDocumentMetadata.Validate()
-	assert.NotNil(t, actual)
+	err := invalidDocumentMetadata.Validate()
+	assert.NotNil(t, err)
+	assert.Equal(t, "metadata.schema.uri can't be empty", err.Error())
 }
 
-func TestValidateDocMetadata_emptySchemaVersion(t *testing.T) {
+func TestDocumentMetadata_Validate_EmptySchemaVersion(t *testing.T) {
 	invalidDocumentMetadata := DocumentMetadata{
 		ContentUri: "http://www.contentUri.com",
 		Schema: &DocumentMetadataSchema{
@@ -62,11 +114,12 @@ func TestValidateDocMetadata_emptySchemaVersion(t *testing.T) {
 		Proof: "proof",
 	}
 
-	actual := invalidDocumentMetadata.Validate()
-	assert.NotNil(t, actual)
+	err := invalidDocumentMetadata.Validate()
+	assert.NotNil(t, err)
+	assert.Equal(t, "metadata.schema.version can't be empty", err.Error())
 }
 
-func TestValidateDocMetadata_emptyProof(t *testing.T) {
+func TestDocumentMetadata_Validate_EmptyProof(t *testing.T) {
 	invalidDocumentMetadata := DocumentMetadata{
 		ContentUri: "http://www.contentUri.com",
 		Schema: &DocumentMetadataSchema{
@@ -76,6 +129,7 @@ func TestValidateDocMetadata_emptyProof(t *testing.T) {
 		Proof: "",
 	}
 
-	actual := invalidDocumentMetadata.Validate()
-	assert.NotNil(t, actual)
+	err := invalidDocumentMetadata.Validate()
+	assert.NotNil(t, err)
+	assert.Equal(t, "metadata.proof can't be empty", err.Error())
 }

--- a/x/docs/internal/types/document_metadata_test.go
+++ b/x/docs/internal/types/document_metadata_test.go
@@ -13,23 +13,19 @@ func TestDocumentMetadata_Equals(t *testing.T) {
 			Uri:     "https://example.com/metadata/schema",
 			Version: "1.0.0",
 		},
-		Proof: "123",
 	}
 	assert.True(t, metadata.Equals(metadata))
 }
 
 func TestDocumentMetadata_Equals_DifferentContents(t *testing.T) {
-	metadata := DocumentMetadata{ContentUri: "http://example.com/metadata", Proof: "123"}
+	metadata := DocumentMetadata{ContentUri: "http://example.com/metadata"}
 
-	other := DocumentMetadata{ContentUri: "https://example.com", Proof: metadata.Proof}
-	assert.False(t, metadata.Equals(other))
-
-	other = DocumentMetadata{ContentUri: metadata.ContentUri, Proof: "1234"}
+	other := DocumentMetadata{ContentUri: "https://example.com"}
 	assert.False(t, metadata.Equals(other))
 }
 
 func TestDocumentMetadata_Equals_DifferentSchema(t *testing.T) {
-	metadata := DocumentMetadata{ContentUri: "http://example.com/metadata", Proof: "123"}
+	metadata := DocumentMetadata{ContentUri: "http://example.com/metadata"}
 
 	other := DocumentMetadata{
 		ContentUri: metadata.ContentUri,
@@ -38,7 +34,6 @@ func TestDocumentMetadata_Equals_DifferentSchema(t *testing.T) {
 			Uri:     "https://example.com/metadata/schema",
 			Version: "1.0.0",
 		},
-		Proof: metadata.Proof,
 	}
 	assert.False(t, metadata.Equals(other))
 }
@@ -54,7 +49,6 @@ func TestDocumentMetadata_Validate(t *testing.T) {
 			Uri:     "http://www.contentUri.com",
 			Version: "test",
 		},
-		Proof: "proof",
 	}
 
 	actual := validDocumentMetadata.Validate()
@@ -68,7 +62,6 @@ func TestDocumentMetadata_Validate_EmptyContentUri(t *testing.T) {
 			Uri:     "http://www.contentUri.com",
 			Version: "test",
 		},
-		Proof: "proof",
 	}
 
 	err := invalidDocumentMetadata.Validate()
@@ -81,7 +74,6 @@ func TestDocumentMetadata_Validate_EmptyMetadataInfo(t *testing.T) {
 		ContentUri: "https://example.com/metadata",
 		Schema:     nil,
 		SchemaType: "",
-		Proof:      "proof",
 	}
 
 	err := invalidDocumentMetadata.Validate()
@@ -96,7 +88,6 @@ func TestDocumentMetadata_Validate_EmptySchemaUri(t *testing.T) {
 			Uri:     "",
 			Version: "test",
 		},
-		Proof: "proof",
 	}
 
 	err := invalidDocumentMetadata.Validate()
@@ -111,25 +102,9 @@ func TestDocumentMetadata_Validate_EmptySchemaVersion(t *testing.T) {
 			Uri:     "http://www.contentUri.com",
 			Version: "",
 		},
-		Proof: "proof",
 	}
 
 	err := invalidDocumentMetadata.Validate()
 	assert.NotNil(t, err)
 	assert.Equal(t, "metadata.schema.version can't be empty", err.Error())
-}
-
-func TestDocumentMetadata_Validate_EmptyProof(t *testing.T) {
-	invalidDocumentMetadata := DocumentMetadata{
-		ContentUri: "http://www.contentUri.com",
-		Schema: &DocumentMetadataSchema{
-			Uri:     "http://www.contentUri.com",
-			Version: "test",
-		},
-		Proof: "",
-	}
-
-	err := invalidDocumentMetadata.Validate()
-	assert.NotNil(t, err)
-	assert.Equal(t, "metadata.proof can't be empty", err.Error())
 }

--- a/x/docs/internal/types/document_metadata_test.go
+++ b/x/docs/internal/types/document_metadata_test.go
@@ -1,0 +1,81 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// -------------------------
+// --- MetadataSchema validation
+// -------------------------
+
+func TestValidateDocMetadata_valid(t *testing.T) {
+	validDocumentMetadata := DocumentMetadata{
+		ContentUri: "http://www.contentUri.com",
+		Schema: &DocumentMetadataSchema{
+			Uri:     "http://www.contentUri.com",
+			Version: "test",
+		},
+		Proof: "proof",
+	}
+
+	actual := validDocumentMetadata.Validate()
+	assert.Nil(t, actual)
+}
+
+func TestValidateDocMetadata_emptyContentUri(t *testing.T) {
+	invalidDocumentMetadata := DocumentMetadata{
+		ContentUri: "",
+		Schema: &DocumentMetadataSchema{
+			Uri:     "http://www.contentUri.com",
+			Version: "test",
+		},
+		Proof: "proof",
+	}
+
+	actual := invalidDocumentMetadata.Validate()
+	assert.NotNil(t, actual)
+}
+
+func TestValidateDocMetadata_emptySchemaUri(t *testing.T) {
+	invalidDocumentMetadata := DocumentMetadata{
+		ContentUri: "http://www.contentUri.com",
+		Schema: &DocumentMetadataSchema{
+			Uri:     "",
+			Version: "test",
+		},
+		Proof: "proof",
+	}
+
+	actual := invalidDocumentMetadata.Validate()
+	assert.NotNil(t, actual)
+}
+
+func TestValidateDocMetadata_emptySchemaVersion(t *testing.T) {
+	invalidDocumentMetadata := DocumentMetadata{
+		ContentUri: "http://www.contentUri.com",
+		Schema: &DocumentMetadataSchema{
+			Uri:     "http://www.contentUri.com",
+			Version: "",
+		},
+		Proof: "proof",
+	}
+
+	actual := invalidDocumentMetadata.Validate()
+	assert.NotNil(t, actual)
+}
+
+func TestValidateDocMetadata_emptyProof(t *testing.T) {
+	invalidDocumentMetadata := DocumentMetadata{
+		ContentUri: "http://www.contentUri.com",
+		Schema: &DocumentMetadataSchema{
+			Uri:     "http://www.contentUri.com",
+			Version: "test",
+		},
+		Proof: "",
+	}
+
+	actual := invalidDocumentMetadata.Validate()
+	assert.NotNil(t, actual)
+}

--- a/x/docs/internal/types/document_test.go
+++ b/x/docs/internal/types/document_test.go
@@ -12,7 +12,6 @@ func TestDocument_Equals_NilValues(t *testing.T) {
 		Metadata: DocumentMetadata{
 			ContentUri: "document_metadata_content_uri",
 			SchemaType: "document_metadata_schema_type",
-			Proof:      "document_metadata_proof",
 		},
 		ContentUri:     "",
 		Checksum:       nil,

--- a/x/docs/internal/types/document_test.go
+++ b/x/docs/internal/types/document_test.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDocument_Equals_NilValues(t *testing.T) {
+	document := Document{
+		Uuid: "uuid",
+		Metadata: DocumentMetadata{
+			ContentUri: "document_metadata_content_uri",
+			SchemaType: "document_metadata_schema_type",
+			Proof:      "document_metadata_proof",
+		},
+		ContentUri:     "",
+		Checksum:       nil,
+		EncryptionData: nil,
+	}
+	assert.True(t, document.Equals(document))
+}

--- a/x/docs/internal/types/keys.go
+++ b/x/docs/internal/types/keys.go
@@ -8,6 +8,8 @@ const (
 	SupportedMetadataSchemesStoreKey = StoreKey + "supportedMetadata"
 	MetadataSchemaProposersStoreKey  = StoreKey + "metadataSchemaProposers"
 
+	DocumentStorePrefix = StoreKey + ":document:"
+
 	SentDocumentsPrefix     = StoreKey + ":documents:sent:"
 	ReceivedDocumentsPrefix = StoreKey + ":received:received:"
 

--- a/x/docs/internal/types/metadata.go
+++ b/x/docs/internal/types/metadata.go
@@ -1,6 +1,9 @@
 package types
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 // MetadataSchema contains the information about an
 // officially supported document metadata schema
@@ -20,13 +23,13 @@ func (m MetadataSchema) Equals(other MetadataSchema) bool {
 // Validate allows to validate the content of the schema, returning
 // an error if something is not valid
 func (m MetadataSchema) Validate() error {
-	if len(m.Type) == 0 {
+	if len(strings.TrimSpace(m.Type)) == 0 {
 		return errors.New("type cannot be empty")
 	}
-	if len(m.SchemaUri) == 0 {
+	if len(strings.TrimSpace(m.SchemaUri)) == 0 {
 		return errors.New("uri cannot be empty")
 	}
-	if len(m.Version) == 0 {
+	if len(strings.TrimSpace(m.Version)) == 0 {
 		return errors.New("version cannot be empty")
 	}
 

--- a/x/docs/internal/types/msgs.go
+++ b/x/docs/internal/types/msgs.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/commercionetwork/commercionetwork/x/common/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -120,13 +121,13 @@ func (msg MsgSendDocumentReceipt) ValidateBasic() sdk.Error {
 	if msg.Recipient.Empty() {
 		return sdk.ErrInvalidAddress(msg.Recipient.String())
 	}
-	if len(msg.TxHash) == 0 {
+	if len(strings.TrimSpace(msg.TxHash)) == 0 {
 		return sdk.ErrUnknownRequest("Send Document's Transaction Hash can't be empty")
 	}
 	if !validateUuid(msg.DocumentUuid) {
 		return sdk.ErrUnknownRequest("Invalid document UUID")
 	}
-	if len(msg.Proof) == 0 {
+	if len(strings.TrimSpace(msg.Proof)) == 0 {
 		return sdk.ErrUnknownRequest("Receipt proof can't be empty")
 	}
 

--- a/x/docs/internal/types/msgs.go
+++ b/x/docs/internal/types/msgs.go
@@ -1,11 +1,9 @@
 package types
 
 import (
-	"encoding/hex"
 	"fmt"
-	"regexp"
-	"strings"
 
+	"github.com/commercionetwork/commercionetwork/x/common/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -22,10 +20,18 @@ var algorithms = map[string]int{
 // --- MsgShareDocument
 // ----------------------------------
 
-type MsgShareDocument Document
+type MsgShareDocument struct {
+	Sender     sdk.AccAddress  `json:"sender"`
+	Recipients types.Addresses `json:"recipients"`
+	Document   Document        `json:"document"`
+}
 
-func NewMsgShareDocument(document Document) MsgShareDocument {
-	return MsgShareDocument(document)
+func NewMsgShareDocument(sender sdk.AccAddress, recipients types.Addresses, document Document) MsgShareDocument {
+	return MsgShareDocument{
+		Sender:     sender,
+		Recipients: recipients,
+		Document:   document,
+	}
 }
 
 // RouterKey Implements Msg.
@@ -34,87 +40,56 @@ func (msg MsgShareDocument) Route() string { return ModuleName }
 // Type Implements Msg.
 func (msg MsgShareDocument) Type() string { return MsgTypeShareDocument }
 
-func validateUuid(uuid string) bool {
-	regex := regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
-	return regex.MatchString(uuid)
-}
-
-func validateDocMetadata(docMetadata DocumentMetadata) sdk.Error {
-	if len(docMetadata.ContentUri) == 0 {
-		return sdk.ErrUnknownRequest("MetadataSchema content URI can't be empty")
-	}
-
-	if (docMetadata.Schema == nil) && len(docMetadata.SchemaType) == 0 {
-		return sdk.ErrUnknownRequest("Either schema or schema_type must be defined")
-	}
-
-	if docMetadata.Schema != nil {
-		if len(docMetadata.Schema.Uri) == 0 {
-			return sdk.ErrUnknownRequest("Schema URI can't be empty")
-		}
-		if len(docMetadata.Schema.Version) == 0 {
-			return sdk.ErrUnknownRequest("Schema version can't be empty")
-		}
-	}
-
-	if len(docMetadata.Proof) == 0 {
-		return sdk.ErrUnknownRequest("Computation proof can't be empty")
-	}
-	return nil
-}
-
-func validateChecksum(checksum DocumentChecksum) sdk.Error {
-	if len(checksum.Value) == 0 {
-		return sdk.ErrUnknownRequest("Checksum value can't be empty")
-	}
-	if len(checksum.Algorithm) == 0 {
-		return sdk.ErrUnknownRequest("Checksum algorithm can't be empty")
-	}
-
-	_, err := hex.DecodeString(checksum.Value)
-	if err != nil {
-		return sdk.ErrUnknownRequest("Invalid checksum value (must be hex)")
-	}
-
-	algorithm := strings.ToLower(checksum.Algorithm)
-
-	// Check that the algorithm is valid
-	length, ok := algorithms[algorithm]
-	if !ok {
-		return sdk.ErrUnknownRequest(fmt.Sprintf("Invalid algorithm type %s", algorithm))
-	}
-
-	// Check the validity of the checksum value
-	if len(checksum.Value) != length {
-		return sdk.ErrUnknownRequest(fmt.Sprintf("Invalid checksum length for algorithm %s", algorithm))
-	}
-
-	return nil
-}
-
 // ValidateBasic Implements Msg.
+// TODO: Test more
 func (msg MsgShareDocument) ValidateBasic() sdk.Error {
 	if msg.Sender.Empty() {
 		return sdk.ErrInvalidAddress(msg.Sender.String())
 	}
-	if msg.Recipient.Empty() {
-		return sdk.ErrInvalidAddress(msg.Recipient.String())
+
+	if msg.Recipients.Empty() {
+		return sdk.ErrUnknownRequest("Recipients cannot be empty")
 	}
-	if !validateUuid(msg.Uuid) {
-		return sdk.ErrUnknownRequest("Invalid document UUID")
-	}
-	if len(msg.ContentUri) == 0 {
-		return sdk.ErrUnknownRequest("Document content Uri can't be empty")
+	for _, recipient := range msg.Recipients {
+		if recipient.Empty() {
+			return sdk.ErrInvalidAddress(recipient.String())
+		}
 	}
 
-	err := validateDocMetadata(msg.Metadata)
+	err := msg.Document.Validate()
 	if err != nil {
-		return err
+		return nil
 	}
 
-	err = validateChecksum(msg.Checksum)
-	if err != nil {
-		return err
+	if msg.Document.EncryptionData != nil {
+
+		for _, recipient := range msg.Recipients {
+			found := false
+
+			// Check that each address inside the EncryptionData object is contained inside the list of addresses
+			for _, encAdd := range msg.Document.EncryptionData.Keys {
+
+				// Check that each recipient has an encrypted data associated to it
+				if recipient.Equals(encAdd.Recipient) {
+					found = true
+				}
+
+				if !msg.Recipients.Contains(encAdd.Recipient) {
+					errMsg := fmt.Sprintf(
+						"%s is a recipient inside encryption data but not inside the message",
+						encAdd.Recipient.String(),
+					)
+					return sdk.ErrInvalidAddress(errMsg)
+				}
+			}
+
+			if !found {
+				// The recipient is not found inside the list of encrypted data recipients
+				errMsg := fmt.Sprintf("%s is a recipient but has no encryption data specified", recipient.String())
+				return sdk.ErrInvalidAddress(errMsg)
+			}
+		}
+
 	}
 
 	return nil

--- a/x/docs/internal/types/msgs.go
+++ b/x/docs/internal/types/msgs.go
@@ -7,15 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var algorithms = map[string]int{
-	"md5":     32,
-	"sha-1":   40,
-	"sha-224": 56,
-	"sha-256": 64,
-	"sha-384": 96,
-	"sha-512": 128,
-}
-
 // ----------------------------------
 // --- MsgShareDocument
 // ----------------------------------

--- a/x/docs/internal/types/msgs.go
+++ b/x/docs/internal/types/msgs.go
@@ -40,7 +40,7 @@ func (msg MsgShareDocument) ValidateBasic() sdk.Error {
 	}
 
 	if msg.Recipients.Empty() {
-		return sdk.ErrUnknownRequest("Recipients cannot be empty")
+		return sdk.ErrInvalidAddress("Recipients cannot be empty")
 	}
 	for _, recipient := range msg.Recipients {
 		if recipient.Empty() {

--- a/x/docs/internal/types/msgs_test.go
+++ b/x/docs/internal/types/msgs_test.go
@@ -23,7 +23,6 @@ var msgShareDocumentSchema = MsgShareDocument{
 				Uri:     "http://www.contentUri.com",
 				Version: "test",
 			},
-			Proof: "proof",
 		},
 		Checksum: &DocumentChecksum{
 			Value:     "48656c6c6f20476f7068657221234567",
@@ -40,7 +39,6 @@ var msgShareDocumentSchemaType = MsgShareDocument{
 		Metadata: DocumentMetadata{
 			ContentUri: "http://www.contentUri.com",
 			SchemaType: "uni-sincro",
-			Proof:      "proof",
 		},
 		Checksum: &DocumentChecksum{
 			Value:     "48656c6c6f20476f7068657221234567",

--- a/x/docs/internal/types/msgs_test.go
+++ b/x/docs/internal/types/msgs_test.go
@@ -10,7 +10,7 @@ import (
 
 // Test vars
 var sender, _ = sdk.AccAddressFromBech32("cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0")
-var recipient, _ = sdk.AccAddressFromBech32("cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0")
+var recipient, _ = sdk.AccAddressFromBech32("cosmos1v0yk4hs2nry020ufmu9yhpm39s4scdhhtecvtr")
 var msgShareDocumentSchema = MsgShareDocument{
 	Sender:     sender,
 	Recipients: types.Addresses{recipient},

--- a/x/docs/internal/types/msgs_test.go
+++ b/x/docs/internal/types/msgs_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	"github.com/commercionetwork/commercionetwork/x/common/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,35 +13,39 @@ var sender, _ = sdk.AccAddressFromBech32("cosmos1lwmppctrr6ssnrmuyzu554dzf50apkf
 var recipient, _ = sdk.AccAddressFromBech32("cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0")
 var msgShareDocumentSchema = MsgShareDocument{
 	Sender:     sender,
-	Recipient:  recipient,
-	Uuid:       "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
-	ContentUri: "http://www.contentUri.com",
-	Metadata: DocumentMetadata{
+	Recipients: types.Addresses{recipient},
+	Document: Document{
+		Uuid:       "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
 		ContentUri: "http://www.contentUri.com",
-		Schema: &DocumentMetadataSchema{
-			Uri:     "http://www.contentUri.com",
-			Version: "test",
+		Metadata: DocumentMetadata{
+			ContentUri: "http://www.contentUri.com",
+			Schema: &DocumentMetadataSchema{
+				Uri:     "http://www.contentUri.com",
+				Version: "test",
+			},
+			Proof: "proof",
 		},
-		Proof: "proof",
-	},
-	Checksum: DocumentChecksum{
-		Value:     "48656c6c6f20476f7068657221234567",
-		Algorithm: "md5",
+		Checksum: &DocumentChecksum{
+			Value:     "48656c6c6f20476f7068657221234567",
+			Algorithm: "md5",
+		},
 	},
 }
 var msgShareDocumentSchemaType = MsgShareDocument{
 	Sender:     sender,
-	Recipient:  recipient,
-	Uuid:       "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
-	ContentUri: "http://www.contentUri.com",
-	Metadata: DocumentMetadata{
+	Recipients: types.Addresses{recipient},
+	Document: Document{
+		Uuid:       "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
 		ContentUri: "http://www.contentUri.com",
-		SchemaType: "uni-sincro",
-		Proof:      "proof",
-	},
-	Checksum: DocumentChecksum{
-		Value:     "48656c6c6f20476f7068657221234567",
-		Algorithm: "md5",
+		Metadata: DocumentMetadata{
+			ContentUri: "http://www.contentUri.com",
+			SchemaType: "uni-sincro",
+			Proof:      "proof",
+		},
+		Checksum: &DocumentChecksum{
+			Value:     "48656c6c6f20476f7068657221234567",
+			Algorithm: "md5",
+		},
 	},
 }
 
@@ -68,30 +73,6 @@ func TestMsgShareDocument_ValidateBasic_SchemaType_valid(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestMsgShareDocument_ValidateBasic_invalid(t *testing.T) {
-	invalidMsg := MsgShareDocument{
-		Sender:     sender,
-		Recipient:  recipient,
-		Uuid:       "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
-		ContentUri: "http://www.contentUri.com",
-		Metadata: DocumentMetadata{
-			ContentUri: "http://www.contentUri.com",
-			Schema: &DocumentMetadataSchema{
-				Uri:     "http://www.contentUri.com",
-				Version: "test",
-			},
-			Proof: "proof",
-		},
-		Checksum: DocumentChecksum{
-			Value:     "testValue",
-			Algorithm: "sha-256",
-		},
-	}
-
-	err := invalidMsg.ValidateBasic()
-	assert.NotNil(t, err)
-}
-
 func TestMsgShareDocument_GetSignBytes(t *testing.T) {
 	actual := msgShareDocumentSchema.GetSignBytes()
 	expected := sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msgShareDocumentSchema))
@@ -105,22 +86,22 @@ func TestMsgShareDocument_GetSigners(t *testing.T) {
 }
 
 func TestMsgShareDocument_UnmarshalJson_Schema(t *testing.T) {
-	json := `{"type":"commercio/MsgShareDocument","value":{"sender":"cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0","recipient":"cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0","uuid":"6a2f41a3-c54c-fce8-32d2-0324e1c32e22","content_uri":"http://www.contentUri.com","metadata":{"content_uri":"http://www.contentUri.com","schema":{"uri":"http://www.contentUri.com","version":"test"},"proof":"proof"},"checksum":{"value":"48656c6c6f20476f7068657221234567","algorithm":"md5"}}}`
+	json := `{"type":"commercio/MsgShareDocument","value":{"sender":"cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0","recipients":["cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0"],"document":{"uuid":"6a2f41a3-c54c-fce8-32d2-0324e1c32e22","content_uri":"http://www.contentUri.com","metadata":{"content_uri":"http://www.contentUri.com","schema":{"uri":"http://www.contentUri.com","version":"test"},"proof":"proof"},"checksum":{"value":"48656c6c6f20476f7068657221234567","algorithm":"md5"}}}}`
 
 	var msg MsgShareDocument
 	ModuleCdc.MustUnmarshalJSON([]byte(json), &msg)
 
-	assert.Equal(t, "http://www.contentUri.com", msg.Metadata.Schema.Uri)
-	assert.Equal(t, "test", msg.Metadata.Schema.Version)
+	assert.Equal(t, "http://www.contentUri.com", msg.Document.Metadata.Schema.Uri)
+	assert.Equal(t, "test", msg.Document.Metadata.Schema.Version)
 }
 
 func TestMsgShareDocument_UnmarshalJson_SchemaType(t *testing.T) {
-	json := `{"type":"commercio/MsgShareDocument","value":{"sender":"cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0","recipient":"cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0","uuid":"6a2f41a3-c54c-fce8-32d2-0324e1c32e22","content_uri":"http://www.contentUri.com","metadata":{"content_uri":"http://www.contentUri.com","schema_type":"uni-sincro","proof":"proof"},"checksum":{"value":"48656c6c6f20476f7068657221234567","algorithm":"md5"}}}`
+	json := `{"type":"commercio/MsgShareDocument","value":{"sender":"cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0","recipients":["cosmos1lwmppctrr6ssnrmuyzu554dzf50apkfvd53jx0"],"document":{"uuid":"6a2f41a3-c54c-fce8-32d2-0324e1c32e22","content_uri":"http://www.contentUri.com","metadata":{"content_uri":"http://www.contentUri.com","schema_type":"uni-sincro","proof":"proof"},"checksum":{"value":"48656c6c6f20476f7068657221234567","algorithm":"md5"}}}}`
 
 	var msg MsgShareDocument
 	ModuleCdc.MustUnmarshalJSON([]byte(json), &msg)
 
-	assert.Equal(t, "uni-sincro", msg.Metadata.SchemaType)
+	assert.Equal(t, "uni-sincro", msg.Document.Metadata.SchemaType)
 }
 
 // ----------------------
@@ -140,158 +121,6 @@ func TestValidateUuid_empty(t *testing.T) {
 func TestValidateUuid_invalid(t *testing.T) {
 	actual := validateUuid("ebkfkd")
 	assert.False(t, actual)
-}
-
-// -------------------------
-// --- MetadataSchema validation
-// -------------------------
-
-func TestValidateDocMetadata_valid(t *testing.T) {
-	validDocumentMetadata := DocumentMetadata{
-		ContentUri: "http://www.contentUri.com",
-		Schema: &DocumentMetadataSchema{
-			Uri:     "http://www.contentUri.com",
-			Version: "test",
-		},
-		Proof: "proof",
-	}
-
-	actual := validateDocMetadata(validDocumentMetadata)
-	assert.Nil(t, actual)
-}
-
-func TestValidateDocMetadata_emptyContentUri(t *testing.T) {
-	invalidDocumentMetadata := DocumentMetadata{
-		ContentUri: "",
-		Schema: &DocumentMetadataSchema{
-			Uri:     "http://www.contentUri.com",
-			Version: "test",
-		},
-		Proof: "proof",
-	}
-
-	actual := validateDocMetadata(invalidDocumentMetadata)
-	assert.NotNil(t, actual)
-}
-
-func TestValidateDocMetadata_emptySchemaUri(t *testing.T) {
-	invalidDocumentMetadata := DocumentMetadata{
-		ContentUri: "http://www.contentUri.com",
-		Schema: &DocumentMetadataSchema{
-			Uri:     "",
-			Version: "test",
-		},
-		Proof: "proof",
-	}
-
-	actual := validateDocMetadata(invalidDocumentMetadata)
-	assert.NotNil(t, actual)
-}
-
-func TestValidateDocMetadata_emptySchemaVersion(t *testing.T) {
-	invalidDocumentMetadata := DocumentMetadata{
-		ContentUri: "http://www.contentUri.com",
-		Schema: &DocumentMetadataSchema{
-			Uri:     "http://www.contentUri.com",
-			Version: "",
-		},
-		Proof: "proof",
-	}
-
-	actual := validateDocMetadata(invalidDocumentMetadata)
-	assert.NotNil(t, actual)
-}
-
-func TestValidateDocMetadata_emptyProof(t *testing.T) {
-	invalidDocumentMetadata := DocumentMetadata{
-		ContentUri: "http://www.contentUri.com",
-		Schema: &DocumentMetadataSchema{
-			Uri:     "http://www.contentUri.com",
-			Version: "test",
-		},
-		Proof: "",
-	}
-
-	actual := validateDocMetadata(invalidDocumentMetadata)
-	assert.NotNil(t, actual)
-}
-
-// --------------------------
-// --- Checksum validation
-// --------------------------
-
-func TestValidateChecksum_validChecksum(t *testing.T) {
-	var checksumList = map[string]string{
-		"md5":     "0cc175b9c0f1b6a831c399e269772661",
-		"sha-1":   "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8",
-		"sha-224": "abd37534c7d9a2efb9465de931cd7055ffdb8879563ae98078d6d6d5",
-		"sha-256": "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
-		"sha-384": "54a59b9f22b0b80880d8427e548b7c23abd873486e1f035dce9cd697e85175033caa88e6d57bc35efae0b5afd3145f31",
-		"sha-512": "1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75",
-	}
-
-	for key, value := range checksumList {
-		checksum := DocumentChecksum{Algorithm: key, Value: value}
-		actual := validateChecksum(checksum)
-		assert.Nil(t, actual)
-	}
-}
-
-func TestValidateChecksum_emptyValue(t *testing.T) {
-	invalidChecksum := DocumentChecksum{
-		Value:     "",
-		Algorithm: "md5",
-	}
-
-	actual := validateChecksum(invalidChecksum)
-	assert.NotNil(t, actual)
-}
-
-func TestValidateChecksum_emptyAlgorithm(t *testing.T) {
-	invalidChecksum := DocumentChecksum{
-		Value:     "48656c6c6f20476f7068657221234567",
-		Algorithm: "",
-	}
-
-	actual := validateChecksum(invalidChecksum)
-	assert.NotNil(t, actual)
-}
-
-func TestValidateChecksum_invalidHexValue(t *testing.T) {
-	invalidChecksum := DocumentChecksum{
-		Value:     "qr54g7srg5674fsg4sfg",
-		Algorithm: "md5",
-	}
-
-	actual := validateChecksum(invalidChecksum)
-	assert.NotNil(t, actual)
-}
-
-func TestValidateChecksum_invalidAlgorithmType(t *testing.T) {
-	invalidChecksum := DocumentChecksum{
-		Value:     "48656c6c6f20476f7068657221234567",
-		Algorithm: "md6",
-	}
-
-	actual := validateChecksum(invalidChecksum)
-	assert.NotNil(t, actual)
-}
-
-func TestValidateChecksum_invalidChecksumLengths(t *testing.T) {
-	var checksumList = map[string]string{
-		"md5":     "0cc175bc0f1b6a831c399e269772661",
-		"sha-1":   "86f7e437faa5a7fce15dddcb9eaeaea377667b8",
-		"sha-224": "abd37534c7d9a2efb946de931cd7055ffdb8879563ae98078d6d6d5",
-		"sha-256": "ca978112ca1bbdcafac21b39a23dc4da786eff8147c4e72b9807785afee48bb",
-		"sha-384": "54a59b9f22b0b80880d427e548b7c23abd873486e1f035dce9cd697e85175033caa88e6d57bc35efae0b5afd3145f31",
-		"sha-512": "1f40fc92da24169475099ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75",
-	}
-
-	for key, value := range checksumList {
-		checksum := DocumentChecksum{Algorithm: key, Value: value}
-		actual := validateChecksum(checksum)
-		assert.NotNil(t, actual)
-	}
 }
 
 // -----------------------------

--- a/x/id/internal/keeper/keeper_test.go
+++ b/x/id/internal/keeper/keeper_test.go
@@ -54,7 +54,7 @@ func TestKeeper_GetIdentities(t *testing.T) {
 	store := ctx.KVStore(k.StoreKey)
 	iterator := sdk.KVStorePrefixIterator(store, []byte(types.IdentitiesStorePrefix))
 	for ; iterator.Valid(); iterator.Next() {
-		store.Delete(iterator.Key())
+
 	}
 
 	first, err := sdk.AccAddressFromBech32("cosmos18xffcd029jn3thr0wwxah6gjdldr3kchvydkuj")

--- a/x/id/internal/keeper/keeper_test.go
+++ b/x/id/internal/keeper/keeper_test.go
@@ -52,10 +52,6 @@ func TestKeeper_GetDidDocumentUriByDid(t *testing.T) {
 func TestKeeper_GetIdentities(t *testing.T) {
 	_, ctx, k := SetupTestInput()
 	store := ctx.KVStore(k.StoreKey)
-	iterator := sdk.KVStorePrefixIterator(store, []byte(types.IdentitiesStorePrefix))
-	for ; iterator.Valid(); iterator.Next() {
-
-	}
 
 	first, err := sdk.AccAddressFromBech32("cosmos18xffcd029jn3thr0wwxah6gjdldr3kchvydkuj")
 	second, err := sdk.AccAddressFromBech32("cosmos18t0e6fevehhjv682gkxpchvmnl7z7ue4t4w0nd")

--- a/x/id/internal/types/msgs.go
+++ b/x/id/internal/types/msgs.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"strings"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -27,7 +29,7 @@ func (msg MsgSetIdentity) ValidateBasic() sdk.Error {
 	if msg.Owner.Empty() {
 		return sdk.ErrInvalidAddress(msg.Owner.String())
 	}
-	if len(msg.DidDocumentUri) == 0 {
+	if len(strings.TrimSpace(msg.DidDocumentUri)) == 0 {
 		return sdk.ErrUnknownRequest("Did Document reference cannot be empty")
 	}
 	return nil

--- a/x/memberships/internal/types/membership.go
+++ b/x/memberships/internal/types/membership.go
@@ -19,7 +19,6 @@ type Membership struct {
 }
 
 // IsMembershipTypeValid returns true iff the given membership type if valid
-// TODO: Test this
 func IsMembershipTypeValid(membershipType string) bool {
 	return membershipType == MembershipTypeGreen ||
 		membershipType == MembershipTypeBronze ||

--- a/x/memberships/internal/types/msgs.go
+++ b/x/memberships/internal/types/msgs.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"strings"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -32,7 +34,7 @@ func (msg MsgAssignMembership) ValidateBasic() sdk.Error {
 	if msg.User.Empty() {
 		return sdk.ErrInvalidAddress(msg.User.String())
 	}
-	if len(msg.MembershipType) == 0 {
+	if len(strings.TrimSpace(msg.MembershipType)) == 0 {
 		return sdk.ErrUnknownRequest("Did Document reference cannot be empty")
 	}
 	if !IsMembershipTypeValid(msg.MembershipType) {


### PR DESCRIPTION
### Changes
- Split the various document related types into many files to better handle them
- Changed the way the documents are stored inside the chain state: now they are all stored using their ids, without replicating them for the sender and the recipient. Those two will have a list of ids instead of documents now
- Removed any internal import inside the tests using the aliases as descried inside #26
- Added the possibility of sending one document to multiple recipients using one single transaction
- Added the option to specify an encryption key for each recipient and to specify which data has been encrypted