### PR TITLE
Do not keep a local Version variable

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	"github.com/cosmos/cosmos-sdk/x/nft"
 	"github.com/cosmos/cosmos-sdk/x/supply"
+	"github.com/cosmos/cosmos-sdk/version"
 
 	"github.com/commercionetwork/commercionetwork/x/docs"
 
@@ -48,7 +49,6 @@ import (
 
 const (
 	appName = "Commercio.network"
-	Version = "1.3.1"
 
 	DefaultBondDenom   = "ucommercio"
 	StableCreditsDenom = "uccc"
@@ -189,7 +189,7 @@ func NewCommercioNetworkApp(logger log.Logger, db dbm.DB, traceStore io.Writer, 
 	// BaseApp handles interactions with Tendermint through the ABCI protocol
 	bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), baseAppOptions...)
 	bApp.SetCommitMultiStoreTracer(traceStore)
-	bApp.SetAppVersion(Version)
+	bApp.SetAppVersion(version.Version)
 
 	keys := sdk.NewKVStoreKeys(
 		// Basics

--- a/cmd/cncli/main.go
+++ b/cmd/cncli/main.go
@@ -35,9 +35,6 @@ func main() {
 	// Configure cobra to sort commands
 	cobra.EnableCommandSorting = false
 
-	// Set the command version
-	version.Version = app.Version
-
 	// Instantiate the codec for the command line application
 	cdc := app.MakeCodec()
 

--- a/cmd/cnd/main.go
+++ b/cmd/cnd/main.go
@@ -33,9 +33,6 @@ const flagInvCheckPeriod = "inv-check-period"
 var invCheckPeriod uint
 
 func main() {
-	// Set the command version
-	version.Version = app.Version
-
 	// Instantiate the codec for the command line application
 	cdc := app.MakeCodec()
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,5 @@ require (
 	github.com/tendermint/tm-db v0.2.0
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect
 	golang.org/x/text v0.3.2 // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190701230453-710ae3a149df // indirect
 )


### PR DESCRIPTION
Use cosmos-sdk/version package and Go's build tags to handle versioning
for us.
Makefile has been updated accordingly, inspired by
https://github.com/cosmos/gaia/blob/master/Makefile.

Output of `cnd version --full` after this change:

```
gsora@metropolis ~/c/commercionetwork> cnd version --long
name: commercionetwork
server_name: cnd
client_name: cndcli
version: 1.3.1-2-gec6631a
commit: ec6631a6a6a2905fc3ac5f4463a16b515ac2f383
build_tags: netgo
go: go version go1.13.3 linux/amd64
```

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Checklist
- [x] Targeted PR against correct branch
- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For Admin Use:
- [x] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [x] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]"