### PR TITLE
Don't use an NFT to represent memberships

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -171,7 +171,6 @@ type CommercioNetworkApp struct {
 	govKeeper      gov.Keeper
 	crisisKeeper   crisis.Keeper
 	paramsKeeper   params.Keeper
-	nftKeeper      nft.Keeper
 
 	// Encapsulated modules
 	customBankKeeper custombank.Keeper
@@ -253,14 +252,13 @@ func NewCommercioNetworkApp(logger log.Logger, db dbm.DB, traceStore io.Writer, 
 		app.cdc, keys[slashing.StoreKey], &stakingKeeper, slashingSubspace, slashing.DefaultCodespace,
 	)
 	app.crisisKeeper = crisis.NewKeeper(crisisSubspace, invCheckPeriod, app.supplyKeeper, auth.FeeCollectorName)
-	app.nftKeeper = nft.NewKeeper(app.cdc, app.keys[nft.StoreKey])
 
 	// Encapsulated modules
 	app.customBankKeeper = custombank.NewKeeper(app.cdc, app.keys[custombank.StoreKey], app.bankKeeper)
 
 	// Custom modules
 	app.governmentKeeper = government.NewKeeper(app.cdc, app.keys[government.StoreKey])
-	app.membershipKeeper = memberships.NewKeeper(app.cdc, app.keys[memberships.StoreKey], app.nftKeeper, app.supplyKeeper)
+	app.membershipKeeper = memberships.NewKeeper(app.cdc, app.keys[memberships.StoreKey], app.supplyKeeper)
 	app.docsKeeper = docs.NewKeeper(app.keys[docs.StoreKey], app.governmentKeeper, app.cdc)
 	app.idKeeper = id.NewKeeper(app.cdc, app.keys[id.StoreKey], app.accountKeeper, app.supplyKeeper)
 	app.priceFeedKeeper = pricefeed.NewKeeper(app.cdc, app.keys[pricefeed.StoreKey])
@@ -288,7 +286,6 @@ func NewCommercioNetworkApp(logger log.Logger, db dbm.DB, traceStore io.Writer, 
 		supply.NewAppModule(app.supplyKeeper, app.accountKeeper),
 		distr.NewAppModule(app.distrKeeper, app.supplyKeeper),
 		slashing.NewAppModule(app.slashingKeeper, app.stakingKeeper),
-		nft.NewAppModule(app.nftKeeper),
 		staking.NewAppModule(app.stakingKeeper, app.accountKeeper, app.supplyKeeper),
 		gov.NewAppModule(app.govKeeper, app.supplyKeeper),
 		crisis.NewAppModule(&app.crisisKeeper),

--- a/x/memberships/alias.go
+++ b/x/memberships/alias.go
@@ -21,6 +21,8 @@ var (
 
 	NewMembership         = types.NewMembership
 	IsMembershipTypeValid = types.IsMembershipTypeValid
+
+	RegisterInvariants = keeper.RegisterInvariants
 )
 
 type (

--- a/x/memberships/genesis.go
+++ b/x/memberships/genesis.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/commercionetwork/commercionetwork/x/memberships/internal/types"
+
 	ctypes "github.com/commercionetwork/commercionetwork/x/common/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/supply"
@@ -69,9 +71,12 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, supplyKeeper supply.Keeper, dat
 
 // ExportGenesis returns a GenesisState for a given context and keeper.
 func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
-	ms, err := keeper.GetMembershipsSet(ctx)
-	if err != nil {
-		panic(err)
+	// create the Memberships set
+	var ms types.Memberships
+	i := keeper.MembershipIterator(ctx)
+	defer i.Close()
+	for ; i.Valid(); i.Next() {
+		ms = append(ms, keeper.ExtractMembership(i.Key(), i.Value()))
 	}
 
 	return GenesisState{

--- a/x/memberships/genesis.go
+++ b/x/memberships/genesis.go
@@ -57,7 +57,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, supplyKeeper supply.Keeper, dat
 
 	// Import the memberships
 	for _, membership := range data.Memberships {
-		_, err := keeper.AssignMembership(ctx, membership.Owner, membership.MembershipType)
+		err := keeper.AssignMembership(ctx, membership.Owner, membership.MembershipType)
 		if err != nil {
 			panic(err)
 		}
@@ -69,12 +69,17 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, supplyKeeper supply.Keeper, dat
 
 // ExportGenesis returns a GenesisState for a given context and keeper.
 func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
+	ms, err := keeper.GetMembershipsSet(ctx)
+	if err != nil {
+		panic(err)
+	}
+
 	return GenesisState{
 		LiquidityPoolAmount:     keeper.GetPoolFunds(ctx),
 		Invites:                 keeper.GetInvites(ctx),
 		TrustedServiceProviders: keeper.GetTrustedServiceProviders(ctx),
 		Credentials:             keeper.GetCredentials(ctx),
-		Memberships:             keeper.GetMembershipsSet(ctx),
+		Memberships:             ms,
 		StableCreditsDenom:      keeper.GetStableCreditsDenom(ctx),
 	}
 }

--- a/x/memberships/internal/keeper/commons_test.go
+++ b/x/memberships/internal/keeper/commons_test.go
@@ -55,9 +55,8 @@ func SetupTestInput() (sdk.Context, bank.Keeper, government.Keeper, keeper.Keepe
 	sk.SetSupply(ctx, supply.NewSupply(sdk.NewCoins(sdk.NewInt64Coin("stake", 1))))
 
 	govk := government.NewKeeper(cdc, keys[government.StoreKey])
-	nftk := nft.NewKeeper(cdc, keys[nft.StoreKey])
 
-	k := keeper.NewKeeper(cdc, keys[types.StoreKey], nftk, sk)
+	k := keeper.NewKeeper(cdc, keys[types.StoreKey], sk)
 
 	// Set module accounts
 	memAcc := supply.NewEmptyModuleAccount(types.ModuleName, supply.Minter, supply.Burner)

--- a/x/memberships/internal/keeper/handler.go
+++ b/x/memberships/internal/keeper/handler.go
@@ -31,7 +31,7 @@ func NewHandler(keeper Keeper, governmentKeeper government.Keeper) sdk.Handler {
 
 func handleMsgInviteUser(ctx sdk.Context, keeper Keeper, msg types.MsgInviteUser) sdk.Result {
 	// Verify that the user that is inviting has already a membership
-	if _, found := keeper.GetMembership(ctx, msg.Sender); !found {
+	if _, err := keeper.GetMembership(ctx, msg.Sender); err != nil {
 		return sdk.ErrUnauthorized("Cannot send an invitation without having a membership").Result()
 	}
 
@@ -100,9 +100,9 @@ func handleMsgBuyMembership(ctx sdk.Context, keeper Keeper, msg types.MsgBuyMemb
 	}
 
 	// Make sure the user can upgrade
-	membership, found := keeper.GetMembership(ctx, msg.Buyer)
-	if found && !types.CanUpgrade(keeper.GetMembershipType(membership), msg.MembershipType) {
-		errMsg := fmt.Sprintf("Cannot upgrade from %s membership to %s", keeper.GetMembershipType(membership), msg.MembershipType)
+	membership, err := keeper.GetMembership(ctx, msg.Buyer)
+	if err == nil && !types.CanUpgrade(membership.MembershipType, msg.MembershipType) {
+		errMsg := fmt.Sprintf("Cannot upgrade from %s membership to %s", membership.MembershipType, msg.MembershipType)
 		return sdk.ErrUnknownRequest(errMsg).Result()
 	}
 

--- a/x/memberships/internal/keeper/handler_test.go
+++ b/x/memberships/internal/keeper/handler_test.go
@@ -52,7 +52,7 @@ func Test_handleMsgInviteUser(t *testing.T) {
 			}
 
 			if len(test.membershipType) != 0 {
-				_, _ = k.AssignMembership(ctx, test.invitee, test.membershipType)
+				_ = k.AssignMembership(ctx, test.invitee, test.membershipType)
 			}
 
 			handler := keeper.NewHandler(k, govK)
@@ -236,7 +236,7 @@ func TestHandler_ValidMsgAssignMembership(t *testing.T) {
 			ctx, bk, gk, k := SetupTestInput()
 
 			if !test.invite.Empty() {
-				_, err := k.AssignMembership(ctx, test.invite.Sender, types.MembershipTypeBlack)
+				err := k.AssignMembership(ctx, test.invite.Sender, types.MembershipTypeBlack)
 				assert.NoError(t, err)
 				k.SaveInvite(ctx, test.invite)
 			}
@@ -251,7 +251,7 @@ func TestHandler_ValidMsgAssignMembership(t *testing.T) {
 				assert.NoError(t, err)
 
 				if len(test.existingMembership) != 0 {
-					_, err = k.AssignMembership(ctx, msg.Buyer, test.existingMembership)
+					err = k.AssignMembership(ctx, msg.Buyer, test.existingMembership)
 					assert.NoError(t, err)
 				}
 			}

--- a/x/memberships/internal/keeper/invariants.go
+++ b/x/memberships/internal/keeper/invariants.go
@@ -1,0 +1,71 @@
+package keeper
+
+import (
+	"fmt"
+
+	"github.com/commercionetwork/commercionetwork/x/memberships/internal/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// RegisterInvariants registers all staking invariants
+func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper) {
+	ir.RegisterRoute(types.ModuleName, "user-membership-verifier",
+		MembershipVerifiedInvariant(k))
+}
+
+func MembershipVerifiedInvariant(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		// get all the users with membership
+		users, err := k.GetMembershipsSet(ctx)
+		if err != nil {
+			panic(err)
+		}
+
+		for _, user := range users {
+			credentials := k.GetUserCredentials(ctx, user.Owner)
+
+			// check that the user has been invited
+			_, found := k.GetInvite(ctx, user.Owner)
+			if !found {
+				return sdk.FormatInvariant(
+					types.ModuleName,
+					"user-membership-verifier",
+					fmt.Sprintf(
+						"found user with membership but with no invite: %s",
+						user.Owner.String(),
+					),
+				), false
+			}
+
+			// check that there are credentials for user
+			if len(credentials) == 0 {
+				return sdk.FormatInvariant(
+					types.ModuleName,
+					"user-membership-verifier",
+					fmt.Sprintf(
+						"found user with membership but with no credentials: %s",
+						user.Owner.String(),
+					),
+				), false
+			}
+
+			// for each credential, check that the Verifier is actually
+			// a tsp
+			for _, credential := range credentials {
+				if !k.IsTrustedServiceProvider(ctx, credential.Verifier) {
+					return sdk.FormatInvariant(
+						types.ModuleName,
+						"user-membership-verifier",
+						fmt.Sprintf(
+							"found user whose credential was verified by a non-Verifier %s user but with no credentials: %s",
+							credential.Verifier.String(),
+							user.Owner.String(),
+						),
+					), false
+				}
+			}
+		}
+
+		return "", true
+	}
+}

--- a/x/memberships/internal/keeper/invariants.go
+++ b/x/memberships/internal/keeper/invariants.go
@@ -16,12 +16,10 @@ func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper) {
 func MembershipVerifiedInvariant(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		// get all the users with membership
-		users, err := k.GetMembershipsSet(ctx)
-		if err != nil {
-			panic(err)
-		}
-
-		for _, user := range users {
+		i := k.MembershipIterator(ctx)
+		defer i.Close()
+		for ; i.Valid(); i.Next() {
+			user := k.ExtractMembership(i.Key(), i.Value())
 			credentials := k.GetUserCredentials(ctx, user.Owner)
 
 			// check that the user has been invited

--- a/x/memberships/internal/keeper/keeper.go
+++ b/x/memberships/internal/keeper/keeper.go
@@ -137,7 +137,7 @@ func (k Keeper) GetMembershipsSet(ctx sdk.Context) (types.Memberships, error) {
 	iterator := sdk.KVStorePrefixIterator(store, []byte(types.MembershipsStorageKey))
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
-		rawAddress := strings.TrimPrefix(string(iterator.Key()), "accreditations:storage:")
+		rawAddress := strings.TrimPrefix(string(iterator.Key()), types.MembershipsStorageKey)
 		address, err := sdk.AccAddressFromBech32(rawAddress)
 		if err != nil {
 			return types.Memberships{}, sdk.ErrUnknownRequest(

--- a/x/memberships/internal/keeper/keeper.go
+++ b/x/memberships/internal/keeper/keeper.go
@@ -9,7 +9,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/supply"
 	"github.com/cosmos/modules/incubator/nft"
-	"github.com/cosmos/modules/incubator/nft/exported"
 )
 
 var membershipCosts = map[string]int64{
@@ -27,7 +26,7 @@ type Keeper struct {
 }
 
 // NewKeeper creates new instances of the accreditation module Keeper
-func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, nftK nft.Keeper, supplyKeeper supply.Keeper) Keeper {
+func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, supplyKeeper supply.Keeper) Keeper {
 
 	// ensure commerciomint module account is set
 	if addr := supplyKeeper.GetModuleAddress(types.ModuleName); addr == nil {
@@ -37,20 +36,13 @@ func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, nftK nft.Keeper, supplyK
 	return Keeper{
 		Cdc:          cdc,
 		StoreKey:     storeKey,
-		NftKeeper:    nftK,
 		SupplyKeeper: supplyKeeper,
 	}
 }
 
-// getMembershipTokenID allows to retrieve the id of a token representing a membership associated to the given user
-func (k Keeper) getMembershipTokenID(user sdk.AccAddress) string {
-	return "membership-" + user.String()
-}
-
-// getMembershipURI allows to returns the URI of the NFT that represents a membership of the
-// given membershipType and having the given id
-func (k Keeper) getMembershipURI(membershipType string, id string) string {
-	return fmt.Sprintf("membership:%s:%s", membershipType, id)
+// storageForAddr returns a string representing the KVStore storage key for an addr.
+func storageForAddr(addr sdk.AccAddress) []byte {
+	return []byte(types.MembershipsStorageKey + addr.String())
 }
 
 // BuyMembership allow to commerciomint and assign a membership of the given membershipType to the specified user.
@@ -67,7 +59,7 @@ func (k Keeper) BuyMembership(ctx sdk.Context, buyer sdk.AccAddress, membershipT
 	}
 
 	// Assign the membership
-	if _, err := k.AssignMembership(ctx, buyer, membershipType); err != nil {
+	if err := k.AssignMembership(ctx, buyer, membershipType); err != nil {
 		return err
 	}
 
@@ -77,86 +69,91 @@ func (k Keeper) BuyMembership(ctx sdk.Context, buyer sdk.AccAddress, membershipT
 // AssignMembership allow to commerciomint and assign a membership of the given membershipType to the specified user.
 // If the user already has a membership assigned, deletes the current one and assigns to it the new one.
 // Returns the URI of the new minted token represented the assigned membership, or an error if something goes w
-func (k Keeper) AssignMembership(ctx sdk.Context, user sdk.AccAddress, membershipType string) (string, sdk.Error) {
+func (k Keeper) AssignMembership(ctx sdk.Context, user sdk.AccAddress, membershipType string) sdk.Error {
 	// Check the membership type validity
 	if !types.IsMembershipTypeValid(membershipType) {
-		return "", sdk.ErrUnknownRequest(fmt.Sprintf("Invalid membership type: %s", membershipType))
+		return sdk.ErrUnknownRequest(fmt.Sprintf("Invalid membership type: %s", membershipType))
 	}
 
-	// Find any existing membership
-	if err := k.RemoveMembership(ctx, user); err != nil {
-		return "", sdk.ErrUnknownRequest(err.Error())
+	_ = k.RemoveMembership(ctx, user)
+
+	store := ctx.KVStore(k.StoreKey)
+
+	staddr := storageForAddr(user)
+	if store.Has(staddr) {
+		return sdk.ErrUnknownRequest(
+			fmt.Sprintf(
+				"cannot add membership \"%s\" for address %s: user already have a membership",
+				membershipType,
+				user.String(),
+			),
+		)
 	}
 
-	// Build the token information
-	id := k.getMembershipTokenID(user)
-	uri := k.getMembershipURI(membershipType, id)
+	store.Set(staddr, k.Cdc.MustMarshalBinaryBare(membershipType))
 
-	// Build the membership token
-	membershipToken := nft.NewBaseNFT(id, user, uri)
-
-	// Mint the token
-	if err := k.NftKeeper.MintNFT(ctx, types.NftDenom, &membershipToken); err != nil {
-		return "", err
-	}
-
-	// Return with no error
-	return membershipToken.TokenURI, nil
+	return nil
 }
 
 // GetMembership allows to retrieve any existent membership for the specified user.
 // The second returned false (the boolean one) tells if the NFT token representing the membership was found or not
-func (k Keeper) GetMembership(ctx sdk.Context, user sdk.AccAddress) (exported.NFT, bool) {
-	foundToken, err := k.NftKeeper.GetNFT(ctx, types.NftDenom, k.getMembershipTokenID(user))
+func (k Keeper) GetMembership(ctx sdk.Context, user sdk.AccAddress) (types.Membership, sdk.Error) {
+	store := ctx.KVStore(k.StoreKey)
 
-	// The token was not found
-	if err != nil {
-		return nil, false
+	if !store.Has(storageForAddr(user)) {
+		return types.Membership{}, sdk.ErrUnknownRequest(
+			fmt.Sprintf("membership not found for user \"%s\"", user.String()),
+		)
 	}
 
-	return foundToken, true
+	membershipRaw := store.Get(storageForAddr(user))
+	var ms types.Membership
+	k.Cdc.MustUnmarshalBinaryBare(membershipRaw, &ms.MembershipType)
+	ms.Owner = user
+
+	return ms, nil
 }
 
 // RemoveMembership allows to remove any existing membership associated with the given user.
 func (k Keeper) RemoveMembership(ctx sdk.Context, user sdk.AccAddress) sdk.Error {
-	id := k.getMembershipTokenID(user)
+	store := ctx.KVStore(k.StoreKey)
 
-	if found, _ := k.NftKeeper.GetNFT(ctx, types.NftDenom, id); found == nil {
-		// The token was not found, so it's trivial to delete it: simply do nothing
-		return nil
+	if !store.Has(storageForAddr(user)) {
+		return sdk.ErrUnknownRequest(
+			fmt.Sprintf("account \"%s\" does not have any membership", user.String()),
+		)
 	}
 
-	if err := k.NftKeeper.DeleteNFT(ctx, types.NftDenom, k.getMembershipTokenID(user)); err != nil {
-		// The token was found, but an error was raised during the deletion. Return the error
-		return err
-	}
+	store.Delete(storageForAddr(user))
 
-	// The token was found and deleted
 	return nil
-}
-
-// GetMembershipType returns the type of the membership represented by the given NFT token
-func (k Keeper) GetMembershipType(membership exported.NFT) string {
-	return strings.Split(membership.GetTokenURI(), ":")[1]
 }
 
 // Get GetMembershipsSet returns the list of all the memberships
 // that have been minted and are currently stored inside the store
-func (k Keeper) GetMembershipsSet(ctx sdk.Context) types.Memberships {
-	collection, found := k.NftKeeper.GetCollection(ctx, types.NftDenom)
-	if !found {
-		return nil
-	}
+func (k Keeper) GetMembershipsSet(ctx sdk.Context) (types.Memberships, error) {
+	store := ctx.KVStore(k.StoreKey)
 
-	memberships := make(types.Memberships, len(collection.NFTs))
-	for index, membershipNft := range collection.NFTs {
-		memberships[index] = types.Membership{
-			Owner:          membershipNft.GetOwner(),
-			MembershipType: k.GetMembershipType(membershipNft),
+	ms := types.Memberships{}
+
+	iterator := sdk.KVStorePrefixIterator(store, []byte(types.MembershipsStorageKey))
+	for ; iterator.Valid(); iterator.Next() {
+		rawAddress := strings.TrimPrefix(string(iterator.Key()), "accreditations:storage:")
+		address, err := sdk.AccAddressFromBech32(rawAddress)
+		if err != nil {
+			return types.Memberships{}, sdk.ErrUnknownRequest(
+				fmt.Sprintf("found membership with invalid address: \"%s\"", rawAddress),
+			)
 		}
+		membership := ""
+		k.Cdc.MustUnmarshalBinaryBare(iterator.Value(), &membership)
+		ms = append(ms, types.Membership{
+			MembershipType: membership,
+			Owner:          address,
+		})
 	}
 
-	return memberships
+	return ms, nil
 }
 
 // GetStableCreditsDenom returns the denom that must be used when referring to stable credits

--- a/x/memberships/internal/keeper/keeper.go
+++ b/x/memberships/internal/keeper/keeper.go
@@ -135,6 +135,7 @@ func (k Keeper) GetMembershipsSet(ctx sdk.Context) (types.Memberships, error) {
 	ms := types.Memberships{}
 
 	iterator := sdk.KVStorePrefixIterator(store, []byte(types.MembershipsStorageKey))
+	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		rawAddress := strings.TrimPrefix(string(iterator.Key()), "accreditations:storage:")
 		address, err := sdk.AccAddressFromBech32(rawAddress)

--- a/x/memberships/internal/keeper/keeper.go
+++ b/x/memberships/internal/keeper/keeper.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/commercionetwork/commercionetwork/x/memberships/internal/types"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -125,35 +124,6 @@ func (k Keeper) RemoveMembership(ctx sdk.Context, user sdk.AccAddress) sdk.Error
 	store.Delete(k.storageForAddr(user))
 
 	return nil
-}
-
-// Get GetMembershipsSet returns the list of all the memberships
-// that have been minted and are currently stored inside the store
-func (k Keeper) GetMembershipsSet(ctx sdk.Context) (types.Memberships, error) {
-	store := ctx.KVStore(k.StoreKey)
-
-	ms := types.Memberships{}
-
-	iterator := sdk.KVStorePrefixIterator(store, []byte(types.MembershipsStorageKey))
-	defer iterator.Close()
-	for ; iterator.Valid(); iterator.Next() {
-		rawAddress := strings.TrimPrefix(string(iterator.Key()), types.MembershipsStorageKey)
-		address, err := sdk.AccAddressFromBech32(rawAddress)
-		if err != nil {
-			return types.Memberships{}, sdk.ErrUnknownRequest(
-				fmt.Sprintf("found membership with invalid address: \"%s\"", rawAddress),
-			)
-		}
-
-		membership := ""
-		k.Cdc.MustUnmarshalBinaryBare(iterator.Value(), &membership)
-		ms = append(ms, types.Membership{
-			MembershipType: membership,
-			Owner:          address,
-		})
-	}
-
-	return ms, nil
 }
 
 // GetMembershipIterator returns an Iterator for all the memberships stored.

--- a/x/memberships/internal/keeper/keeper.go
+++ b/x/memberships/internal/keeper/keeper.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/supply"
-	"github.com/cosmos/modules/incubator/nft"
 )
 
 var membershipCosts = map[string]int64{
@@ -21,7 +20,6 @@ var membershipCosts = map[string]int64{
 type Keeper struct {
 	Cdc          *codec.Codec
 	StoreKey     sdk.StoreKey
-	NftKeeper    nft.Keeper
 	SupplyKeeper supply.Keeper
 }
 

--- a/x/memberships/internal/keeper/keeper_rewards.go
+++ b/x/memberships/internal/keeper/keeper_rewards.go
@@ -44,18 +44,18 @@ func (k Keeper) DepositIntoPool(ctx sdk.Context, depositor sdk.AccAddress, amoun
 // DistributeReward allows to distribute the rewards to the sender of the specified invite upon the receiver has
 // properly bought a membership of the given membershipType
 func (k Keeper) DistributeReward(ctx sdk.Context, invite types.Invite) sdk.Error {
-	senderMembership, found := k.GetMembership(ctx, invite.Sender)
-	if !found {
+	senderMembership, err := k.GetMembership(ctx, invite.Sender)
+	if err != nil {
 		return sdk.ErrUnauthorized("Invite sender does not have a membership")
 	}
 
-	recipientMembership, found := k.GetMembership(ctx, invite.User)
-	if !found {
+	recipientMembership, err := k.GetMembership(ctx, invite.User)
+	if err != nil {
 		return sdk.ErrUnauthorized("Invite recipient does not have a membership")
 	}
 
-	senderMembershipType := k.GetMembershipType(senderMembership)
-	recipientMembershipType := k.GetMembershipType(recipientMembership)
+	senderMembershipType := senderMembership.MembershipType
+	recipientMembershipType := recipientMembership.MembershipType
 
 	// Get the reward amount by searching up inside the matrix.
 	// Multiply the found amount by 1.000.000 as coins are represented as millionth of units, and make it an int

--- a/x/memberships/internal/keeper/keeper_rewards_test.go
+++ b/x/memberships/internal/keeper/keeper_rewards_test.go
@@ -156,8 +156,8 @@ func TestKeeper_DistributeReward(t *testing.T) {
 			ctx, bk, _, k := SetupTestInput()
 
 			k.SaveInvite(ctx, test.invite)
-			_, _ = k.AssignMembership(ctx, test.invite.Sender, test.inviteSenderMembership)
-			_, _ = k.AssignMembership(ctx, test.invite.User, test.inviteRecipientMembership)
+			_ = k.AssignMembership(ctx, test.invite.Sender, test.inviteSenderMembership)
+			_ = k.AssignMembership(ctx, test.invite.User, test.inviteRecipientMembership)
 
 			_ = k.SupplyKeeper.MintCoins(ctx, types.ModuleName, test.poolFunds)
 

--- a/x/memberships/internal/keeper/keeper_test.go
+++ b/x/memberships/internal/keeper/keeper_test.go
@@ -54,40 +54,40 @@ func TestKeeper_AssignMembership(t *testing.T) {
 
 func TestKeeper_RemoveMembership(t *testing.T) {
 	tests := []struct {
-		name        string
-		memberships types.Memberships
-		membership  types.Membership
-		expected    types.Memberships
+		name       string
+		membership types.Membership
+		mustError  bool
 	}{
 		{
-			name:        "Non existing membership works properly",
-			memberships: types.Memberships{},
-			membership:  types.NewMembership(types.MembershipTypeBronze, testUser),
-			expected:    types.Memberships{},
+			name:       "Non existing membership throws an error",
+			membership: types.NewMembership(types.MembershipTypeBronze, testUser),
+			mustError:  true,
 		},
 		{
-			name: "Existing membership is removed properly",
-			memberships: types.Memberships{
-				types.NewMembership(types.MembershipTypeBronze, testUser),
-				types.NewMembership(types.MembershipTypeGold, testUser2),
-			},
+			name:       "Existing membership is removed properly",
 			membership: types.NewMembership(types.MembershipTypeBronze, testUser),
-			expected: types.Memberships{
-				types.NewMembership(types.MembershipTypeGold, testUser2),
-			},
+			mustError:  false,
 		},
 	}
 
 	for _, test := range tests {
 		ctx, _, _, k := SetupTestInput()
 
-		for _, m := range test.memberships {
-			_ = k.AssignMembership(ctx, m.Owner, m.MembershipType)
+		// if the test should not throw an error when removing, we must add
+		// a membership first
+		if !test.mustError {
+			_ = k.AssignMembership(ctx, test.membership.Owner, test.membership.MembershipType)
 		}
 
-		_ = k.RemoveMembership(ctx, test.membership.Owner)
-		set, _ := k.GetMembershipsSet(ctx)
-		assert.True(t, test.expected.Equals(set))
+		err := k.RemoveMembership(ctx, test.membership.Owner)
+		if !test.mustError {
+			assert.NoError(t, err)
+		} else {
+			assert.Error(t, err)
+		}
+
+		_, err = k.GetMembership(ctx, test.membership.Owner)
+		assert.Error(t, err)
 	}
 }
 
@@ -135,7 +135,7 @@ func TestKeeper_GetMembership(t *testing.T) {
 	}
 }
 
-func TestKeeper_GetMembershipsSet(t *testing.T) {
+func TestKeeper_MembershipIterator(t *testing.T) {
 	tests := []struct {
 		name              string
 		storedMemberships types.Memberships
@@ -162,10 +162,50 @@ func TestKeeper_GetMembershipsSet(t *testing.T) {
 				err := k.AssignMembership(ctx, m.Owner, m.MembershipType)
 				assert.NoError(t, err)
 			}
+			i := k.MembershipIterator(ctx)
+			for ; i.Valid(); i.Next() {
+				m := k.ExtractMembership(i.Key(), i.Value())
+				assert.Contains(t, test.storedMemberships, m)
+			}
+		})
+	}
+}
 
-			set, _ := k.GetMembershipsSet(ctx)
-			for _, m := range test.storedMemberships {
-				assert.Contains(t, set, m)
+func TestKeeper_ExtractMembership(t *testing.T) {
+	tests := []struct {
+		name       string
+		key        []byte
+		value      []byte
+		membership types.Membership
+		mustFail   bool
+	}{
+		{
+			"a good membership",
+			[]byte{97, 99, 99, 114, 101, 100, 105, 116, 97, 116, 105, 111, 110, 115, 58, 115, 116, 111, 114, 97, 103, 101, 58, 20, 153, 39, 56, 31, 38, 42, 65, 168, 74, 73, 145, 237, 226, 147, 118, 104, 171, 0, 46, 239},
+			[]byte{6, 98, 114, 111, 110, 122, 101},
+			types.NewMembership(types.MembershipTypeBronze, testUser),
+			false,
+		},
+		{
+			"a badly serialized membership",
+			[]byte{99, 99, 114, 101, 100, 105, 116, 97, 116, 105, 111, 110, 115, 58, 115, 116, 111, 114, 97, 103, 101, 58, 20, 153, 39, 56, 31, 38, 42, 65, 168, 74, 73, 145, 237, 226, 147, 118, 104, 171, 0, 46, 239},
+			[]byte{6, 114, 111, 110, 122, 101},
+			types.Membership{},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			_, _, _, k := SetupTestInput()
+			if !test.mustFail {
+				m := k.ExtractMembership(test.key, test.value)
+				assert.Equal(t, test.membership, m)
+			} else {
+				assert.Panics(t, func() {
+					_ = k.ExtractMembership(test.key, test.value)
+				})
 			}
 		})
 	}

--- a/x/memberships/internal/keeper/querier.go
+++ b/x/memberships/internal/keeper/querier.go
@@ -105,12 +105,13 @@ func queryResolveMembership(ctx sdk.Context, path []string, keeper Keeper) (res 
 		User: address,
 	}
 
-	// TODO: can we invert this flow to use the err != nil convention?
 	// Search the membership
-	if membership, err := keeper.GetMembership(ctx, address); err == nil {
-		result.MembershipType = membership.MembershipType
+	membership, err := keeper.GetMembership(ctx, address)
+	if err != nil {
+		return nil, err
 	}
 
+	result.MembershipType = membership.MembershipType
 	bz, err2 := codec.MarshalJSONIndent(keeper.Cdc, result)
 	if err2 != nil {
 		return nil, sdk.ErrUnknownRequest("Could not marshal result to JSON")

--- a/x/memberships/internal/keeper/querier.go
+++ b/x/memberships/internal/keeper/querier.go
@@ -105,9 +105,10 @@ func queryResolveMembership(ctx sdk.Context, path []string, keeper Keeper) (res 
 		User: address,
 	}
 
+	// TODO: can we invert this flow to use the err != nil convention?
 	// Search the membership
-	if membership, found := keeper.GetMembership(ctx, address); found {
-		result.MembershipType = keeper.GetMembershipType(membership)
+	if membership, err := keeper.GetMembership(ctx, address); err == nil {
+		result.MembershipType = membership.MembershipType
 	}
 
 	bz, err2 := codec.MarshalJSONIndent(keeper.Cdc, result)

--- a/x/memberships/internal/keeper/querier_test.go
+++ b/x/memberships/internal/keeper/querier_test.go
@@ -185,7 +185,7 @@ func Test_queryResolveMembership(t *testing.T) {
 		ctx, _, _, k := SetupTestInput()
 
 		if !(types.Membership{}).Equals(test.existingMembership) {
-			_, _ = k.AssignMembership(ctx, test.existingMembership.Owner, test.existingMembership.MembershipType)
+			_ = k.AssignMembership(ctx, test.existingMembership.Owner, test.existingMembership.MembershipType)
 		}
 
 		querier := keeper.NewQuerier(k)

--- a/x/memberships/internal/keeper/querier_test.go
+++ b/x/memberships/internal/keeper/querier_test.go
@@ -169,15 +169,18 @@ func Test_queryResolveMembership(t *testing.T) {
 		name               string
 		existingMembership types.Membership
 		expected           keeper.MembershipResult
+		mustErr            bool
 	}{
 		{
 			name:               "Existing membership is returned properly",
 			existingMembership: types.NewMembership(types.MembershipTypeGold, testUser),
 			expected:           keeper.MembershipResult{User: testUser, MembershipType: types.MembershipTypeGold},
+			mustErr:            false,
 		},
 		{
 			name:     "Not found membership returns correctly",
 			expected: keeper.MembershipResult{User: testUser, MembershipType: ""},
+			mustErr:  true,
 		},
 	}
 
@@ -191,10 +194,15 @@ func Test_queryResolveMembership(t *testing.T) {
 		querier := keeper.NewQuerier(k)
 
 		path := []string{types.QueryGetMembership, testUser.String()}
-		actualBz, _ := querier(ctx, path, request)
+		actualBz, err := querier(ctx, path, request)
 
-		var actual keeper.MembershipResult
-		k.Cdc.MustUnmarshalJSON(actualBz, &actual)
-		assert.Equal(t, test.expected, actual)
+		if !test.mustErr {
+			assert.NoError(t, err)
+			var actual keeper.MembershipResult
+			k.Cdc.MustUnmarshalJSON(actualBz, &actual)
+			assert.Equal(t, test.expected, actual)
+		} else {
+			assert.Error(t, err)
+		}
 	}
 }

--- a/x/memberships/internal/types/keys.go
+++ b/x/memberships/internal/types/keys.go
@@ -6,9 +6,8 @@ const (
 	RouterKey    = ModuleName
 	QuerierRoute = ModuleName
 
-	NftDenom = "membership"
-
 	// --- Keeper
+	MembershipsStorageKey  = StoreKey + ":storage:"
 	StableCreditsStoreKey  = StoreKey + ":stableCreditsDenom"
 	TrustedSignersStoreKey = StoreKey + ":signers"
 	InviteStorePrefix      = "invite:"

--- a/x/memberships/module.go
+++ b/x/memberships/module.go
@@ -111,7 +111,9 @@ func (AppModule) Name() string {
 }
 
 // register invariants
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
+	RegisterInvariants(ir, am.keeper)
+}
 
 // module message route name
 func (AppModule) Route() string {


### PR DESCRIPTION
Changed memberships logic from an NFT-based approach to a simpler approach using just Cosmos storage methods, as adviced in the security review.

---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Checklist
- [x] Targeted PR against correct branch
- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For Admin Use:
- [x] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [ ] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]"