### PR TITLE
Add commerciomint invariants

### DIFF
--- a/x/commerciomint/alias.go
+++ b/x/commerciomint/alias.go
@@ -19,8 +19,9 @@ var (
 	RegisterCodec = types.RegisterCodec
 	ModuleCdc     = types.ModuleCdc
 
-	NewMsgOpenCdp  = types.NewMsgOpenCdp
-	NewMsgCloseCdp = types.NewMsgCloseCdp
+	NewMsgOpenCdp      = types.NewMsgOpenCdp
+	NewMsgCloseCdp     = types.NewMsgCloseCdp
+	RegisterInvariants = keeper.RegisterInvariants
 )
 
 type (

--- a/x/commerciomint/internal/keeper/invariants.go
+++ b/x/commerciomint/internal/keeper/invariants.go
@@ -1,0 +1,87 @@
+package keeper
+
+import (
+	"fmt"
+
+	"github.com/commercionetwork/commercionetwork/x/commerciomint/internal/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	cdpsForExistingPrice       string = "cdp-existing-price"
+	liquidityPoolSumEqualsCdps string = "liquidity-pool-sum-equals-cdps"
+)
+
+func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper) {
+	ir.RegisterRoute(types.ModuleName, cdpsForExistingPrice,
+		CdpsForExistingPrice(k))
+	ir.RegisterRoute(types.ModuleName, liquidityPoolSumEqualsCdps,
+		LiquidityPoolAmountEqualsCdps(k))
+}
+
+// CdpsForExistingPrice checks that each Cdp currently opened refers to an existing token priced by x/pricefeed.
+func CdpsForExistingPrice(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		cdps := k.GetCdps(ctx)
+
+		for _, cdp := range cdps {
+			for _, depositAmount := range cdp.DepositedAmount {
+				_, ok := k.priceFeedKeeper.GetCurrentPrice(ctx, depositAmount.Denom)
+				if !ok {
+					return sdk.FormatInvariant(
+						types.ModuleName,
+						cdpsForExistingPrice,
+						fmt.Sprintf(
+							"found cdp from owner %s which refers to a nonexistent asset %s for %s amount",
+							cdp.Owner.String(),
+							depositAmount.Denom,
+							depositAmount.Amount.String(),
+						),
+					), true
+				}
+			}
+		}
+		return "", false
+	}
+}
+
+// LiquidityPoolAmountEqualsCdps checks that the value of all the opened cdps equals the liquidity pool amount.
+func LiquidityPoolAmountEqualsCdps(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		cdps := k.GetCdps(ctx)
+
+		sums := make(map[string]sdk.Int)
+		for _, cdp := range cdps {
+			for _, depositAmount := range cdp.DepositedAmount {
+				if _, ok := sums[depositAmount.Denom]; !ok {
+					sums[depositAmount.Denom] = sdk.NewInt(0)
+				}
+
+				sums[depositAmount.Denom] = sums[depositAmount.Denom].Add(depositAmount.Amount)
+			}
+		}
+
+		pool := k.GetLiquidityPoolAmount(ctx)
+
+		for name, sum := range sums {
+			for _, token := range pool {
+				if token.Denom == name {
+					if !sum.Equal(token.Amount) {
+						return sdk.FormatInvariant(
+							types.ModuleName,
+							cdpsForExistingPrice,
+							fmt.Sprintf(
+								"pool amount for denom %s doesn't correspond to the sum of all the cdps opened for it, which is %s%s",
+								name,
+								sum.String(),
+								name,
+							),
+						), true
+					}
+				}
+			}
+		}
+
+		return "", false
+	}
+}

--- a/x/commerciomint/module.go
+++ b/x/commerciomint/module.go
@@ -97,7 +97,9 @@ func NewAppModule(keeper Keeper, sk supply.Keeper) AppModule {
 func (AppModule) Name() string { return ModuleName }
 
 // register invariants
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
+	RegisterInvariants(ir, am.keeper)
+}
 
 // module message route name
 func (AppModule) Route() string { return RouterKey }


### PR DESCRIPTION
This PR adds some invariants for commerciomint, namely:

 - cdpsForExistingPrice, which checks that each Cdp currently opened refers to an existing token priced by x/pricefeed
 - liquidityPoolSumEqualsCdps, which checks that the value of all the opened cdps equals the liquidity pool amount

---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Checklist
- [x] Targeted PR against correct branch
- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For Admin Use:
- [x] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [x] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]"