### PR TITLE
Add fixed fees for all the commercio's messages

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -348,6 +348,14 @@ func NewCommercioNetworkApp(logger log.Logger, db dbm.DB, traceStore io.Writer, 
 		ante.NewAnteHandler(
 			app.accountKeeper, app.supplyKeeper, app.priceFeedKeeper,
 			auth.DefaultSigVerificationGasConsumer, StableCreditsDenom,
+			[]types.MessageLister{
+				app.mintKeeper,
+				app.docsKeeper,
+				app.idKeeper,
+				app.membershipKeeper,
+				app.priceFeedKeeper,
+				app.vbrKeeper,
+			},
 		),
 	)
 	app.SetEndBlocker(app.EndBlocker)

--- a/app/app.go
+++ b/app/app.go
@@ -347,15 +347,14 @@ func NewCommercioNetworkApp(logger log.Logger, db dbm.DB, traceStore io.Writer, 
 	app.SetAnteHandler(
 		ante.NewAnteHandler(
 			app.accountKeeper, app.supplyKeeper, app.priceFeedKeeper,
-			auth.DefaultSigVerificationGasConsumer, StableCreditsDenom,
-			[]types.MessageLister{
-				app.mintKeeper,
-				app.docsKeeper,
-				app.idKeeper,
-				app.membershipKeeper,
-				app.priceFeedKeeper,
-				app.vbrKeeper,
-			},
+			auth.DefaultSigVerificationGasConsumer,
+			StableCreditsDenom,
+			app.mintKeeper,
+			app.docsKeeper,
+			app.idKeeper,
+			app.membershipKeeper,
+			app.priceFeedKeeper,
+			app.vbrKeeper,
 		),
 	)
 	app.SetEndBlocker(app.EndBlocker)

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -3,6 +3,8 @@ package simapp
 import (
 	"io"
 
+	"github.com/commercionetwork/commercionetwork/x/docs"
+
 	"github.com/commercionetwork/commercionetwork/x/government"
 	"github.com/commercionetwork/commercionetwork/x/pricefeed"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -96,6 +98,7 @@ type SimApp struct {
 
 	GovernmentKeeper government.Keeper
 	PriceFeedKeeper  pricefeed.Keeper
+	DocsKeeper       docs.Keeper
 
 	// the module manager
 	mm *module.Manager
@@ -118,7 +121,7 @@ func NewSimApp(
 
 	keys := sdk.NewKVStoreKeys(bam.MainStoreKey, auth.StoreKey, staking.StoreKey,
 		supply.StoreKey, mint.StoreKey, distr.StoreKey, slashing.StoreKey,
-		gov.StoreKey, params.StoreKey, pricefeed.StoreKey)
+		gov.StoreKey, params.StoreKey, pricefeed.StoreKey, docs.StoreKey)
 	tkeys := sdk.NewTransientStoreKeys(params.TStoreKey)
 
 	app := &SimApp{
@@ -154,6 +157,7 @@ func NewSimApp(
 	app.CrisisKeeper = crisis.NewKeeper(crisisSubspace, invCheckPeriod, app.SupplyKeeper, auth.FeeCollectorName)
 	app.GovernmentKeeper = government.NewKeeper(app.cdc, keys[government.StoreKey])
 	app.PriceFeedKeeper = pricefeed.NewKeeper(app.cdc, keys[pricefeed.StoreKey])
+	app.DocsKeeper = docs.NewKeeper(app.keys[docs.StoreKey], app.GovernmentKeeper, app.cdc)
 
 	// register the proposal types
 	govRouter := gov.NewRouter()
@@ -183,6 +187,7 @@ func NewSimApp(
 		slashing.NewAppModule(app.SlashingKeeper, app.StakingKeeper),
 		staking.NewAppModule(app.StakingKeeper, app.AccountKeeper, app.SupplyKeeper),
 		pricefeed.NewAppModule(app.PriceFeedKeeper, app.GovernmentKeeper),
+		docs.NewAppModule(app.DocsKeeper),
 	)
 
 	// During begin block slashing happens after distr.BeginBlocker so that
@@ -198,7 +203,7 @@ func NewSimApp(
 		auth.ModuleName, distr.ModuleName, staking.ModuleName,
 		bank.ModuleName, slashing.ModuleName, gov.ModuleName,
 		mint.ModuleName, supply.ModuleName, crisis.ModuleName,
-		genutil.ModuleName,
+		genutil.ModuleName, docs.ModuleName,
 	)
 
 	app.mm.RegisterInvariants(&app.CrisisKeeper)

--- a/x/ante/ante_test.go
+++ b/x/ante/ante_test.go
@@ -64,7 +64,7 @@ func TestAnteHandlerFees_MsgShareDoc(t *testing.T) {
 	anteHandler := ante.NewAnteHandler(
 		app.AccountKeeper, app.SupplyKeeper, app.PriceFeedKeeper,
 		cosmosante.DefaultSigVerificationGasConsumer,
-		stableCreditsDenom, []ctypes.MessageLister{app.DocsKeeper},
+		stableCreditsDenom, app.DocsKeeper,
 	)
 
 	// Keys and addresses

--- a/x/ante/ante_test.go
+++ b/x/ante/ante_test.go
@@ -64,7 +64,7 @@ func TestAnteHandlerFees_MsgShareDoc(t *testing.T) {
 	anteHandler := ante.NewAnteHandler(
 		app.AccountKeeper, app.SupplyKeeper, app.PriceFeedKeeper,
 		cosmosante.DefaultSigVerificationGasConsumer,
-		stableCreditsDenom,
+		stableCreditsDenom, []ctypes.MessageLister{app.DocsKeeper},
 	)
 
 	// Keys and addresses

--- a/x/commerciomint/internal/keeper/keeper.go
+++ b/x/commerciomint/internal/keeper/keeper.go
@@ -3,6 +3,8 @@ package keeper
 import (
 	"fmt"
 
+	ctypes "github.com/commercionetwork/commercionetwork/x/common/types"
+
 	"github.com/commercionetwork/commercionetwork/x/commerciomint/internal/types"
 	"github.com/commercionetwork/commercionetwork/x/pricefeed"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -195,10 +197,10 @@ func (k Keeper) deleteCdp(ctx sdk.Context, cdp types.Cdp) {
 	}
 }
 
-// Messages implements the MessageLister interface.
-func (k Keeper) Messages() []string {
-	return []string{
-		types.MsgTypeCloseCdp,
-		types.MsgTypeOpenCdp,
+// Messages implements the MessageFeeBinder interface.
+func (k Keeper) Messages() []ctypes.MessageFeeBinding {
+	return []ctypes.MessageFeeBinding{
+		ctypes.NewStandardBinding(types.MsgTypeCloseCdp),
+		ctypes.NewStandardBinding(types.MsgTypeOpenCdp),
 	}
 }

--- a/x/commerciomint/internal/keeper/keeper.go
+++ b/x/commerciomint/internal/keeper/keeper.go
@@ -194,3 +194,11 @@ func (k Keeper) deleteCdp(ctx sdk.Context, cdp types.Cdp) {
 		}
 	}
 }
+
+// Messages implements the MessageLister interface.
+func (k Keeper) Messages() []string {
+	return []string{
+		types.MsgTypeCloseCdp,
+		types.MsgTypeOpenCdp,
+	}
+}

--- a/x/commerciomint/internal/keeper/keeper_test.go
+++ b/x/commerciomint/internal/keeper/keeper_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	ctypes "github.com/commercionetwork/commercionetwork/x/common/types"
+
 	"github.com/commercionetwork/commercionetwork/x/commerciomint/internal/types"
 	"github.com/commercionetwork/commercionetwork/x/pricefeed"
 	"github.com/stretchr/testify/require"
@@ -261,6 +263,28 @@ func TestKeeper_DeleteCdp(t *testing.T) {
 			} else {
 				require.Len(t, result, len(test.existingCdps))
 			}
+		})
+	}
+}
+
+func TestKeeper_Messages(t *testing.T) {
+	tests := []struct {
+		name string
+		want []ctypes.MessageFeeBinding
+	}{
+		{
+			"expected Messages",
+			[]ctypes.MessageFeeBinding{
+				ctypes.NewStandardBinding(types.MsgTypeCloseCdp),
+				ctypes.NewStandardBinding(types.MsgTypeOpenCdp),
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, k := SetupTestInput()
+			require.Equal(t, tt.want, k.Messages())
 		})
 	}
 }

--- a/x/common/types/message_fixed_fees.go
+++ b/x/common/types/message_fixed_fees.go
@@ -1,0 +1,28 @@
+package types
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+// MessageFeeBinder is an interface implemented by keepers which contains the method "Messages", which returns a string
+// slice containing all the messages supported by said keeper.
+type MessageFeeBinder interface {
+	Messages() []MessageFeeBinding
+}
+
+// MessageFeeBinding represent a constant fee to be required by x/ante when handling messages named after Name.
+type MessageFeeBinding struct {
+	Name string
+	Fee  sdk.Dec
+}
+
+// StandardFIATFee is the fixed 0.01€ fee Commercio.network requires for each transaction.
+// Each Keeper can define a different fee for each message, although most of Commercio.network modules
+// will use StandardFIATFee.
+var StandardFIATFee = sdk.NewDecWithPrec(1, 2)
+
+// NewStandardBinding returns a new MessageFeeBinding initialized with StandardFIATFee and messageName.
+func NewStandardBinding(messageName string) MessageFeeBinding {
+	return MessageFeeBinding{
+		Name: messageName,
+		Fee:  StandardFIATFee,
+	}
+}

--- a/x/common/types/message_fixed_fees_test.go
+++ b/x/common/types/message_fixed_fees_test.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStandardBinding(t *testing.T) {
+	tests := []struct {
+		name        string
+		messageName string
+		want        MessageFeeBinding
+	}{
+		{
+			"MsgTypeShareDoc standard fee binding",
+			"MsgTypeShareDoc",
+			MessageFeeBinding{
+				Name: "MsgTypeShareDoc",
+				Fee:  StandardFIATFee,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mb := NewStandardBinding(tt.messageName)
+			require.Equal(t, tt.want, mb)
+		})
+	}
+}

--- a/x/common/types/message_lister.go
+++ b/x/common/types/message_lister.go
@@ -1,7 +1,0 @@
-package types
-
-// MessageLister is an interface implemented by keepers which contains the method "Messages", which returns a string
-// slice containing all the messages supported by said keeper.
-type MessageLister interface {
-	Messages() []string
-}

--- a/x/common/types/message_lister.go
+++ b/x/common/types/message_lister.go
@@ -1,0 +1,7 @@
+package types
+
+// MessageLister is an interface implemented by keepers which contains the method "Messages", which returns a string
+// slice containing all the messages supported by said keeper.
+type MessageLister interface {
+	Messages() []string
+}

--- a/x/docs/alias.go
+++ b/x/docs/alias.go
@@ -11,8 +11,6 @@ const (
 	QuerierRoute = types.QuerierRoute
 
 	MetadataSchemaProposersStoreKey = types.MetadataSchemaProposersStoreKey
-
-	MsgTypeShareDocument = types.MsgTypeShareDocument
 )
 
 var (

--- a/x/docs/internal/keeper/keeper.go
+++ b/x/docs/internal/keeper/keeper.go
@@ -218,3 +218,13 @@ func (keeper Keeper) ExtractTrustedSchemaProposer(iterVal []byte) sdk.AccAddress
 	keeper.cdc.MustUnmarshalBinaryBare(iterVal, &tsp)
 	return tsp
 }
+
+// Messages implements the MessageLister interface.
+func (k Keeper) Messages() []string {
+	return []string{
+		types.MsgTypeAddSupportedMetadataSchema,
+		types.MsgTypeAddTrustedMetadataSchemaProposer,
+		types.MsgTypeSendDocumentReceipt,
+		types.MsgTypeShareDocument,
+	}
+}

--- a/x/docs/internal/keeper/keeper.go
+++ b/x/docs/internal/keeper/keeper.go
@@ -220,7 +220,7 @@ func (keeper Keeper) ExtractTrustedSchemaProposer(iterVal []byte) sdk.AccAddress
 }
 
 // Messages implements the MessageLister interface.
-func (k Keeper) Messages() []string {
+func (keeper Keeper) Messages() []string {
 	return []string{
 		types.MsgTypeAddSupportedMetadataSchema,
 		types.MsgTypeAddTrustedMetadataSchemaProposer,

--- a/x/docs/internal/keeper/keeper.go
+++ b/x/docs/internal/keeper/keeper.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	ctypes "github.com/commercionetwork/commercionetwork/x/common/types"
+
 	"github.com/commercionetwork/commercionetwork/x/docs/internal/types"
 	"github.com/commercionetwork/commercionetwork/x/government"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -219,12 +221,12 @@ func (keeper Keeper) ExtractTrustedSchemaProposer(iterVal []byte) sdk.AccAddress
 	return tsp
 }
 
-// Messages implements the MessageLister interface.
-func (keeper Keeper) Messages() []string {
-	return []string{
-		types.MsgTypeAddSupportedMetadataSchema,
-		types.MsgTypeAddTrustedMetadataSchemaProposer,
-		types.MsgTypeSendDocumentReceipt,
-		types.MsgTypeShareDocument,
+// Messages implements the MessageFeeBinder interface.
+func (keeper Keeper) Messages() []ctypes.MessageFeeBinding {
+	return []ctypes.MessageFeeBinding{
+		ctypes.NewStandardBinding(types.MsgTypeAddSupportedMetadataSchema),
+		ctypes.NewStandardBinding(types.MsgTypeAddTrustedMetadataSchemaProposer),
+		ctypes.NewStandardBinding(types.MsgTypeSendDocumentReceipt),
+		ctypes.NewStandardBinding(types.MsgTypeShareDocument),
 	}
 }

--- a/x/docs/internal/keeper/keeper_test.go
+++ b/x/docs/internal/keeper/keeper_test.go
@@ -766,3 +766,27 @@ func TestKeeper_GetReceiptByID(t *testing.T) {
 		})
 	}
 }
+
+func TestKeeper_Messages(t *testing.T) {
+	tests := []struct {
+		name string
+		want []ctypes.MessageFeeBinding
+	}{
+		{
+			"expected Messages",
+			[]ctypes.MessageFeeBinding{
+				ctypes.NewStandardBinding(types.MsgTypeAddSupportedMetadataSchema),
+				ctypes.NewStandardBinding(types.MsgTypeAddTrustedMetadataSchemaProposer),
+				ctypes.NewStandardBinding(types.MsgTypeSendDocumentReceipt),
+				ctypes.NewStandardBinding(types.MsgTypeShareDocument),
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, k := SetupTestInput()
+			require.Equal(t, tt.want, k.Messages())
+		})
+	}
+}

--- a/x/id/internal/keeper/keeper.go
+++ b/x/id/internal/keeper/keeper.go
@@ -353,15 +353,15 @@ func (k Keeper) FundAccount(ctx sdk.Context, account sdk.AccAddress, amount sdk.
 	return nil
 }
 
-// Messages implements the MessageLister interface.
-func (k Keeper) Messages() []string {
-	return []string{
-		types.MsgTypeInvalidateDidDepositRequest,
-		types.MsgTypeInvalidateDidPowerUpRequest,
-		types.MsgTypeMoveDeposit,
-		types.MsgTypePowerUpDid,
-		types.MsgTypeRequestDidDeposit,
-		types.MsgTypeRequestDidPowerUp,
-		types.MsgTypeSetIdentity,
+// Messages implements the MessageFeeBinder interface.
+func (k Keeper) Messages() []ctypes.MessageFeeBinding {
+	return []ctypes.MessageFeeBinding{
+		ctypes.NewStandardBinding(types.MsgTypeInvalidateDidDepositRequest),
+		ctypes.NewStandardBinding(types.MsgTypeInvalidateDidPowerUpRequest),
+		ctypes.NewStandardBinding(types.MsgTypeMoveDeposit),
+		ctypes.NewStandardBinding(types.MsgTypePowerUpDid),
+		ctypes.NewStandardBinding(types.MsgTypeRequestDidDeposit),
+		ctypes.NewStandardBinding(types.MsgTypeRequestDidPowerUp),
+		ctypes.NewStandardBinding(types.MsgTypeSetIdentity),
 	}
 }

--- a/x/id/internal/keeper/keeper.go
+++ b/x/id/internal/keeper/keeper.go
@@ -352,3 +352,16 @@ func (k Keeper) FundAccount(ctx sdk.Context, account sdk.AccAddress, amount sdk.
 
 	return nil
 }
+
+// Messages implements the MessageLister interface.
+func (k Keeper) Messages() []string {
+	return []string{
+		types.MsgTypeInvalidateDidDepositRequest,
+		types.MsgTypeInvalidateDidPowerUpRequest,
+		types.MsgTypeMoveDeposit,
+		types.MsgTypePowerUpDid,
+		types.MsgTypeRequestDidDeposit,
+		types.MsgTypeRequestDidPowerUp,
+		types.MsgTypeSetIdentity,
+	}
+}

--- a/x/id/internal/keeper/keeper_test.go
+++ b/x/id/internal/keeper/keeper_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"testing"
 
+	ctypes "github.com/commercionetwork/commercionetwork/x/common/types"
+
 	"github.com/commercionetwork/commercionetwork/x/id/internal/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/supply"
@@ -396,4 +398,31 @@ func TestKeeper_GetPoolAmount_NonEmptyCoins(t *testing.T) {
 
 	stored := k.GetPoolAmount(ctx)
 	require.Equal(t, pool, stored)
+}
+
+func TestKeeper_Messages(t *testing.T) {
+	tests := []struct {
+		name string
+		want []ctypes.MessageFeeBinding
+	}{
+		{
+			"expected Messages",
+			[]ctypes.MessageFeeBinding{
+				ctypes.NewStandardBinding(types.MsgTypeInvalidateDidDepositRequest),
+				ctypes.NewStandardBinding(types.MsgTypeInvalidateDidPowerUpRequest),
+				ctypes.NewStandardBinding(types.MsgTypeMoveDeposit),
+				ctypes.NewStandardBinding(types.MsgTypePowerUpDid),
+				ctypes.NewStandardBinding(types.MsgTypeRequestDidDeposit),
+				ctypes.NewStandardBinding(types.MsgTypeRequestDidPowerUp),
+				ctypes.NewStandardBinding(types.MsgTypeSetIdentity),
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, _, _, k := SetupTestInput()
+			require.Equal(t, tt.want, k.Messages())
+		})
+	}
 }

--- a/x/memberships/internal/keeper/keeper.go
+++ b/x/memberships/internal/keeper/keeper.go
@@ -3,6 +3,8 @@ package keeper
 import (
 	"fmt"
 
+	ctypes "github.com/commercionetwork/commercionetwork/x/common/types"
+
 	"github.com/commercionetwork/commercionetwork/x/government"
 
 	"github.com/commercionetwork/commercionetwork/x/memberships/internal/types"
@@ -169,13 +171,13 @@ func (k Keeper) SetStableCreditsDenom(ctx sdk.Context, denom string) {
 	store.Set([]byte(types.StableCreditsStoreKey), []byte(denom))
 }
 
-// Messages implements the MessageLister interface.
-func (k Keeper) Messages() []string {
-	return []string{
-		types.MsgTypesDepositIntoLiquidityPool,
-		types.MsgTypeSetUserVerified,
-		types.MsgTypeAddTsp,
-		types.MsgTypeBuyMembership,
-		types.MsgTypeInviteUser,
+// Messages implements the MessageFeeBinder interface.
+func (k Keeper) Messages() []ctypes.MessageFeeBinding {
+	return []ctypes.MessageFeeBinding{
+		ctypes.NewStandardBinding(types.MsgTypesDepositIntoLiquidityPool),
+		ctypes.NewStandardBinding(types.MsgTypeSetUserVerified),
+		ctypes.NewStandardBinding(types.MsgTypeAddTsp),
+		ctypes.NewStandardBinding(types.MsgTypeBuyMembership),
+		ctypes.NewStandardBinding(types.MsgTypeInviteUser),
 	}
 }

--- a/x/memberships/internal/keeper/keeper.go
+++ b/x/memberships/internal/keeper/keeper.go
@@ -168,3 +168,14 @@ func (k Keeper) SetStableCreditsDenom(ctx sdk.Context, denom string) {
 	store := ctx.KVStore(k.StoreKey)
 	store.Set([]byte(types.StableCreditsStoreKey), []byte(denom))
 }
+
+// Messages implements the MessageLister interface.
+func (k Keeper) Messages() []string {
+	return []string{
+		types.MsgTypesDepositIntoLiquidityPool,
+		types.MsgTypeSetUserVerified,
+		types.MsgTypeAddTsp,
+		types.MsgTypeBuyMembership,
+		types.MsgTypeInviteUser,
+	}
+}

--- a/x/memberships/internal/keeper/keeper_test.go
+++ b/x/memberships/internal/keeper/keeper_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	ctypes "github.com/commercionetwork/commercionetwork/x/common/types"
+
 	"github.com/commercionetwork/commercionetwork/x/memberships/internal/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
@@ -262,6 +264,31 @@ func TestKeeper_GetStableCreditsDenom(t *testing.T) {
 			store.Set([]byte(types.StableCreditsStoreKey), []byte(test.denom))
 
 			require.Equal(t, test.denom, k.GetStableCreditsDenom(ctx))
+		})
+	}
+}
+
+func TestKeeper_Messages(t *testing.T) {
+	tests := []struct {
+		name string
+		want []ctypes.MessageFeeBinding
+	}{
+		{
+			"expected Messages",
+			[]ctypes.MessageFeeBinding{
+				ctypes.NewStandardBinding(types.MsgTypesDepositIntoLiquidityPool),
+				ctypes.NewStandardBinding(types.MsgTypeSetUserVerified),
+				ctypes.NewStandardBinding(types.MsgTypeAddTsp),
+				ctypes.NewStandardBinding(types.MsgTypeBuyMembership),
+				ctypes.NewStandardBinding(types.MsgTypeInviteUser),
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, k := SetupTestInput()
+			require.Equal(t, tt.want, k.Messages())
 		})
 	}
 }

--- a/x/pricefeed/internal/keeper/keeper.go
+++ b/x/pricefeed/internal/keeper/keeper.go
@@ -228,7 +228,7 @@ func (keeper Keeper) GetOracles(ctx sdk.Context) (oracles ctypes.Addresses) {
 }
 
 // Messages implements the MessageLister interface.
-func (k Keeper) Messages() []string {
+func (keeper Keeper) Messages() []string {
 	return []string{
 		types.MsgTypeSetPrice,
 		types.MsgTypeAddOracle,

--- a/x/pricefeed/internal/keeper/keeper.go
+++ b/x/pricefeed/internal/keeper/keeper.go
@@ -227,10 +227,10 @@ func (keeper Keeper) GetOracles(ctx sdk.Context) (oracles ctypes.Addresses) {
 	return oracles
 }
 
-// Messages implements the MessageLister interface.
-func (keeper Keeper) Messages() []string {
-	return []string{
-		types.MsgTypeSetPrice,
-		types.MsgTypeAddOracle,
+// Messages implements the MessageFeeBinder interface.
+func (keeper Keeper) Messages() []ctypes.MessageFeeBinding {
+	return []ctypes.MessageFeeBinding{
+		ctypes.NewStandardBinding(types.MsgTypeSetPrice),
+		ctypes.NewStandardBinding(types.MsgTypeAddOracle),
 	}
 }

--- a/x/pricefeed/internal/keeper/keeper.go
+++ b/x/pricefeed/internal/keeper/keeper.go
@@ -226,3 +226,11 @@ func (keeper Keeper) GetOracles(ctx sdk.Context) (oracles ctypes.Addresses) {
 	keeper.cdc.MustUnmarshalBinaryBare(store.Get([]byte(types.OraclePrefix)), &oracles)
 	return oracles
 }
+
+// Messages implements the MessageLister interface.
+func (k Keeper) Messages() []string {
+	return []string{
+		types.MsgTypeSetPrice,
+		types.MsgTypeAddOracle,
+	}
+}

--- a/x/pricefeed/internal/keeper/keeper_test.go
+++ b/x/pricefeed/internal/keeper/keeper_test.go
@@ -269,3 +269,25 @@ func TestKeeper_GetOracles(t *testing.T) {
 
 	require.Equal(t, expected, k.GetOracles(ctx))
 }
+
+func TestKeeper_Messages(t *testing.T) {
+	tests := []struct {
+		name string
+		want []ctypes.MessageFeeBinding
+	}{
+		{
+			"expected Messages",
+			[]ctypes.MessageFeeBinding{
+				ctypes.NewStandardBinding(types.MsgTypeSetPrice),
+				ctypes.NewStandardBinding(types.MsgTypeAddOracle),
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, k := SetupTestInput()
+			require.Equal(t, tt.want, k.Messages())
+		})
+	}
+}

--- a/x/vbr/internal/keeper/keeper.go
+++ b/x/vbr/internal/keeper/keeper.go
@@ -194,3 +194,10 @@ func (k Keeper) DistributeBlockRewards(ctx sdk.Context, validator exported.Valid
 
 	return nil
 }
+
+// Messages implements the MessageLister interface.
+func (k Keeper) Messages() []string {
+	return []string{
+		types.MsgTypeIncrementBlockRewardsPool,
+	}
+}

--- a/x/vbr/internal/keeper/keeper.go
+++ b/x/vbr/internal/keeper/keeper.go
@@ -195,9 +195,9 @@ func (k Keeper) DistributeBlockRewards(ctx sdk.Context, validator exported.Valid
 	return nil
 }
 
-// Messages implements the MessageLister interface.
-func (k Keeper) Messages() []string {
-	return []string{
-		types.MsgTypeIncrementBlockRewardsPool,
+// Messages implements the MessageFeeBinder interface.
+func (k Keeper) Messages() []ctypes.MessageFeeBinding {
+	return []ctypes.MessageFeeBinding{
+		ctypes.NewStandardBinding(types.MsgTypeIncrementBlockRewardsPool),
 	}
 }

--- a/x/vbr/internal/keeper/keeper_test.go
+++ b/x/vbr/internal/keeper/keeper_test.go
@@ -3,6 +3,8 @@ package keeper
 import (
 	"testing"
 
+	ctypes "github.com/commercionetwork/commercionetwork/x/common/types"
+
 	"github.com/commercionetwork/commercionetwork/x/vbr/internal/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	dist "github.com/cosmos/cosmos-sdk/x/distribution"
@@ -202,4 +204,25 @@ func TestKeeper_DistributeBlockRewards_InsufficientPoolFunds(t *testing.T) {
 	err := k.DistributeBlockRewards(ctx, TestValidator, reward)
 
 	require.Error(t, err)
+}
+
+func TestKeeper_Messages(t *testing.T) {
+	tests := []struct {
+		name string
+		want []ctypes.MessageFeeBinding
+	}{
+		{
+			"expected Messages",
+			[]ctypes.MessageFeeBinding{
+				ctypes.NewStandardBinding(types.MsgTypeIncrementBlockRewardsPool),
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, k, _, _ := SetupTestInput()
+			require.Equal(t, tt.want, k.Messages())
+		})
+	}
 }


### PR DESCRIPTION
This PR adds a fixed minimum uccc/ucommercio fee for all the commercio.network custom messages.

To achieve that, a new interface called `MessageLister` has been created.

Each Keeper which implements `MessageLister` returns a string slice containing all the messages it can handle.

Our `x/ante` implementation now accepts a slice of `MessageLister` in its constructor, then builds a map which links each message type with their fixed minimum fee.

Although this implementation adds a new interface and new Keeper methods, this approach will let us:

 - easily add new modules with an associated minimum required fee
 - assign some modules different minimum required fee

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Checklist
- [x] Targeted PR against correct branch
- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For Admin Use:
- [x] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [x] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]"