### PR TITLE
General Proof calculation algorithm

### DIFF
--- a/x/id/client/cli/tx.go
+++ b/x/id/client/cli/tx.go
@@ -99,7 +99,7 @@ func getSetIdentityCommand(cdc *codec.Codec) *cobra.Command {
 				Context: unsignedDoc.Context,
 				ID:      unsignedDoc.ID,
 				PubKeys: unsignedDoc.PubKeys,
-				Proof:   proof,
+				Proof:   &proof,
 				Service: nil,
 			})
 

--- a/x/id/keeper/test_commons.go
+++ b/x/id/keeper/test_commons.go
@@ -156,7 +156,7 @@ func setupDidDocument() types.DidDocument {
 	return types.DidDocument{
 		Context: types.ContextDidV1,
 		ID:      testOwnerAddress,
-		Proof: types.Proof{
+		Proof: &types.Proof{
 			Type:               types.KeyTypeSecp256k12019,
 			Created:            testTime,
 			ProofPurpose:       types.ProofPurposeAuthentication,

--- a/x/id/types/did_document.go
+++ b/x/id/types/did_document.go
@@ -18,10 +18,11 @@ type DidDocument struct {
 	ID      sdk.AccAddress `json:"id"`
 	PubKeys PubKeys        `json:"publicKey"`
 
-	// To a future reader: to mark a DidDocument field as optional, add `omitempty` to the
-	// JSON decoding tag.
+	// To a future reader, to mark a DidDocument field as optional:
+	//  - tag it with `omitempty` if it's a simple type (i.e. not a struct)
+	//  - make it a pointer if it's a complex type (i.e. a struct)
 
-	// Proof is **NOT** optional, we need it to have omitempty to make the signature procedure more straightforward,
+	// Proof is **NOT** optional, we need it to have omitempty/pointer to make the signature procedure more straightforward,
 	// i.e. DidDocument.Validate() will check if proof is empty, and throw an error if true.
 	Proof *Proof `json:"proof,omitempty"`
 

--- a/x/id/types/did_document.go
+++ b/x/id/types/did_document.go
@@ -150,7 +150,7 @@ func (didDocument DidDocument) Validate() error {
 // The Proof is constructed as follows:
 //  - let K be the Bech32 Account public key, embedded in the Proof "Verification Method" field
 //  - let S be K transformed in a raw Secp256k1 public key
-//  - let B be the SHA-512 (as defined in the FIPS 180-4) of the JSON representation of d minus the Proof field
+//  - let B be the SHA-256 (as defined in the FIPS 180-4) of the JSON representation of d minus the Proof field
 //  - let L be the Proof Signature Value, decoded from Base64 encoding
 // The Proof is verified if K.Verify(B, L) is verified.
 func (didDocument DidDocument) VerifyProof() error {

--- a/x/id/types/did_document_test.go
+++ b/x/id/types/did_document_test.go
@@ -1,11 +1,11 @@
 package types
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	sdkErr "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -248,7 +248,7 @@ func getBaseDocumentWithServices(services []Service) DidDocument {
 				PublicKeyPem: "thePublicKey",
 			},
 		},
-		Proof: Proof{
+		Proof: &Proof{
 			Type:               "someType",
 			Created:            time.Time{},
 			ProofPurpose:       "theProofPurpose",
@@ -257,5 +257,384 @@ func getBaseDocumentWithServices(services []Service) DidDocument {
 			SignatureValue:     "signatureValue",
 		},
 		Service: services,
+	}
+}
+
+func TestDidDocument_VerifyProof(t *testing.T) {
+
+	var testZone, _ = time.LoadLocation("UTC")
+	var testTime = time.Date(2016, 2, 8, 16, 2, 20, 0, testZone)
+	var testOwnerAddress, _ = sdk.AccAddressFromBech32("did:com:12p24st9asf394jv04e8sxrl9c384jjqwejv0gf")
+	okayDDOWrongSig := DidDocument{
+		Context: ContextDidV1,
+		ID:      testOwnerAddress,
+		Proof: &Proof{
+			Type:               KeyTypeSecp256k12019,
+			Created:            testTime,
+			ProofPurpose:       ProofPurposeAuthentication,
+			Controller:         testOwnerAddress.String(),
+			SignatureValue:     "uv9ZM4XusZl2q6Ei2O7aZW32pzwfg6ZQpBsQPb8cxzlFXWEyZLxem29fQBB4Py3W5gaXFEyPGruMXNsNDnr4sQ==",
+			VerificationMethod: "did:com:pub1addwnpepqwzc44ggn40xpwkfhcje9y7wdz6sunuv2uydxmqjrvcwff6npp2exy5dn6c",
+		},
+		PubKeys: PubKeys{
+			PubKey{
+				ID:         fmt.Sprintf("%s#keys-1", testOwnerAddress),
+				Type:       "RsaVerificationKey2018",
+				Controller: testOwnerAddress,
+				PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqOoLR843vgkGudQsjch
+2K85QJ4Hh7l2jjrMesQFDWVcW1xr//eieGzxDogWx7tMOtQ0hw77NAURhldek1Bh
+Co06790YHAE97JqgRQ+IR9Dl3GaGVQ2WcnknO4B1cvTRJmdsqrN1Bs4Qfd+jjKIM
+V1tz8zU9NmdR+DvGkAYYxoIx74YaTAxH+GCArfWMG1tRJPI9MELZbOWd9xkKlPic
+bLp8coZh9NgLajMDWKXpuHQ8cdJSxQ/ekZaTuEy7qbjbGBMVzbjhPjcxffQmGV1W
+gNY1BGplZz9mbBmH7siKnKIVZ5Bp55uLfEw+u2yOVx/0yKUdsmZoe4jhevCSq3aw
+GwIDAQAB
+-----END PUBLIC KEY-----`,
+			},
+			PubKey{
+				ID:         fmt.Sprintf("%s#keys-2", testOwnerAddress),
+				Type:       "RsaSignatureKey2018",
+				Controller: testOwnerAddress,
+				PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+Juw6xqYchTNFYUznmoB
+CzKfQG75v2Pv1Db1Z5EJgP6i0yRsBG1VqIOY4icRnyhDDVFi1omQjjUuCRxWGjsc
+B1UkSnybm0WC+g82HL3mUzbZja27NFJPuNaMaUlNbe0daOG88FS67jq5J2LsZH/V
+cGZBX5bbtCe0Niq39mQdJxdHq3D5ROMA73qeYvLkmXS6Dvs0w0fHsy+DwJtdOnOj
+xt4F5hIEXGP53qz2tBjCRL6HiMP/cLSwAd7oc67abgQxfnf9qldyd3X0IABpti1L
+irJNugfN6HuxHDm6dlXVReOhHRbkEcWedv82Ji5d/sDZ+WT+yWILOq03EJo/LXJ1
+SQIDAQAB
+-----END PUBLIC KEY-----`,
+			},
+		},
+	}
+
+	okayDDO := DidDocument{
+		Context: ContextDidV1,
+		ID:      testOwnerAddress,
+		Proof: &Proof{
+			Type:               KeyTypeSecp256k12019,
+			Created:            testTime,
+			ProofPurpose:       ProofPurposeAuthentication,
+			Controller:         testOwnerAddress.String(),
+			SignatureValue:     "uv9ZM4XusZl2q6Ei2O7aZW32pzwfg6ZQpBsQPb8cxzlFXWEyZLxem29fQBB4Py3W5gaXFEyPGruMXNsNDnr4sQ==",
+			VerificationMethod: "did:com:pub1addwnpepqwzc44ggn40xpwkfhcje9y7wdz6sunuv2uydxmqjrvcwff6npp2exy5dn6c",
+		},
+		PubKeys: PubKeys{
+			PubKey{
+				ID:         fmt.Sprintf("%s#keys-1", testOwnerAddress),
+				Type:       "RsaVerificationKey2018",
+				Controller: testOwnerAddress,
+				PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqOoLR843vgkFGudQsjch
+2K85QJ4Hh7l2jjrMesQFDWVcW1xr//eieGzxDogWx7tMOtQ0hw77NAURhldek1Bh
+Co06790YHAE97JqgRQ+IR9Dl3GaGVQ2WcnknO4B1cvTRJmdsqrN1Bs4Qfd+jjKIM
+V1tz8zU9NmdR+DvGkAYYxoIx74YaTAxH+GCArfWMG1tRJPI9MELZbOWd9xkKlPic
+bLp8coZh9NgLajMDWKXpuHQ8cdJSxQ/ekZaTuEy7qbjbGBMVzbjhPjcxffQmGV1W
+gNY1BGplZz9mbBmH7siKnKIVZ5Bp55uLfEw+u2yOVx/0yKUdsmZoe4jhevCSq3aw
+GwIDAQAB
+-----END PUBLIC KEY-----`,
+			},
+			PubKey{
+				ID:         fmt.Sprintf("%s#keys-2", testOwnerAddress),
+				Type:       "RsaSignatureKey2018",
+				Controller: testOwnerAddress,
+				PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+Juw6xqYchTNFYUznmoB
+CzKfQG75v2Pv1Db1Z5EJgP6i0yRsBG1VqIOY4icRnyhDDVFi1omQjjUuCRxWGjsc
+B1UkSnybm0WC+g82HL3mUzbZja27NFJPuNaMaUlNbe0daOG88FS67jq5J2LsZH/V
+cGZBX5bbtCe0Niq39mQdJxdHq3D5ROMA73qeYvLkmXS6Dvs0w0fHsy+DwJtdOnOj
+xt4F5hIEXGP53qz2tBjCRL6HiMP/cLSwAd7oc67abgQxfnf9qldyd3X0IABpti1L
+irJNugfN6HuxHDm6dlXVReOhHRbkEcWedv82Ji5d/sDZ+WT+yWILOq03EJo/LXJ1
+SQIDAQAB
+-----END PUBLIC KEY-----`,
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		didDocument DidDocument
+		wantErr     bool
+	}{
+		{
+			"pubkey is not bech32",
+			DidDocument{
+				Proof: &Proof{
+					VerificationMethod: "notbech32",
+				},
+			},
+			true,
+		},
+		{
+			"signaturevalue is not base64",
+			DidDocument{
+				Proof: &Proof{
+					VerificationMethod: "did:com:pub1addwnpepqwzc44ggn40xpwkfhcje9y7wdz6sunuv2uydxmqjrvcwff6npp2exy5dn6c",
+					SignatureValue:     "notbase64",
+				},
+			},
+			true,
+		},
+		{
+			"signature wrong",
+			okayDDOWrongSig,
+			true,
+		},
+		{
+			"signature ok, no errors",
+			okayDDO,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.didDocument.VerifyProof()
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDidDocument_Validate(t *testing.T) {
+	var testOwnerAddress, _ = sdk.AccAddressFromBech32("did:com:12p24st9asf394jv04e8sxrl9c384jjqwejv0gf")
+	var testZone, _ = time.LoadLocation("UTC")
+	var testTime = time.Date(2016, 2, 8, 16, 2, 20, 0, testZone)
+
+	tests := []struct {
+		name        string
+		didDocument DidDocument
+		wantErr     bool
+	}{
+		{
+			"empty id",
+			DidDocument{},
+			true,
+		},
+		{
+			"context is not ContextDidV1",
+			DidDocument{
+				Context: "ohno",
+			},
+			true,
+		},
+		{
+			"no pubkeys",
+			DidDocument{
+				ID:      testOwnerAddress,
+				Context: ContextDidV1,
+			},
+			true,
+		},
+		{
+			"no required pubkeys",
+			DidDocument{
+				ID:      testOwnerAddress,
+				Context: ContextDidV1,
+				PubKeys: PubKeys{
+					PubKey{
+						ID:         fmt.Sprintf("%s#keys-1", testOwnerAddress),
+						Type:       "RsaVerificationKey2018",
+						Controller: testOwnerAddress,
+						PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqOoLR843vgkFGudQsjch
+2K85QJ4Hh7l2jjrMesQFDWVcW1xr//eieGzxDogWx7tMOtQ0hw77NAURhldek1Bh
+Co06790YHAE97JqgRQ+IR9Dl3GaGVQ2WcnknO4B1cvTRJmdsqrN1Bs4Qfd+jjKIM
+V1tz8zU9NmdR+DvGkAYYxoIx74YaTAxH+GCArfWMG1tRJPI9MELZbOWd9xkKlPic
+bLp8coZh9NgLajMDWKXpuHQ8cdJSxQ/ekZaTuEy7qbjbGBMVzbjhPjcxffQmGV1W
+gNY1BGplZz9mbBmH7siKnKIVZ5Bp55uLfEw+u2yOVx/0yKUdsmZoe4jhevCSq3aw
+GwIDAQAB
+-----END PUBLIC KEY-----`,
+					},
+				},
+			},
+			true,
+		},
+		{
+			"no required pubkeys",
+			DidDocument{
+				ID:      testOwnerAddress,
+				Context: ContextDidV1,
+				PubKeys: PubKeys{
+					PubKey{
+						ID:         fmt.Sprintf("%s#keys-1", testOwnerAddress),
+						Type:       "RsaVerificationKey2018",
+						Controller: testOwnerAddress,
+						PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqOoLR843vgkFGudQsjch
+2K85QJ4Hh7l2jjrMesQFDWVcW1xr//eieGzxDogWx7tMOtQ0hw77NAURhldek1Bh
+Co06790YHAE97JqgRQ+IR9Dl3GaGVQ2WcnknO4B1cvTRJmdsqrN1Bs4Qfd+jjKIM
+V1tz8zU9NmdR+DvGkAYYxoIx74YaTAxH+GCArfWMG1tRJPI9MELZbOWd9xkKlPic
+bLp8coZh9NgLajMDWKXpuHQ8cdJSxQ/ekZaTuEy7qbjbGBMVzbjhPjcxffQmGV1W
+gNY1BGplZz9mbBmH7siKnKIVZ5Bp55uLfEw+u2yOVx/0yKUdsmZoe4jhevCSq3aw
+GwIDAQAB
+-----END PUBLIC KEY-----`,
+					},
+					PubKey{
+						ID:         fmt.Sprintf("%s#keys-2", testOwnerAddress),
+						Type:       "RsaSignatureKey2018",
+						Controller: testOwnerAddress,
+						PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+Juw6xqYchTNFYUznmoB
+CzKfQG75v2Pv1Db1Z5EJgP6i0yRsBG1VqIOY4icRnyhDDVFi1omQjjUuCRxWGjsc
+B1UkSnybm0WC+g82HL3mUzbZja27NFJPuNaMaUlNbe0daOG88FS67jq5J2LsZH/V
+cGZBX5bbtCe0Niq39mQdJxdHq3D5ROMA73qeYvLkmXS6Dvs0w0fHsy+DwJtdOnOj
+xt4F5hIEXGP53qz2tBjCRL6HiMP/cLSwAd7oc67abgQxfnf9qldyd3X0IABpti1L
+irJNugfN6HuxHDm6dlXVReOhHRbkEcWedv82Ji5d/sDZ+WT+yWILOq03EJo/LXJ1
+SQIDAQAB
+-----END PUBLIC KEY-----`,
+					},
+				},
+			},
+			true,
+		},
+		{
+			"no proof",
+			DidDocument{
+				ID:      testOwnerAddress,
+				Context: ContextDidV1,
+				PubKeys: PubKeys{
+					PubKey{
+						ID:         fmt.Sprintf("%s#keys-1", testOwnerAddress),
+						Type:       "RsaVerificationKey2018",
+						Controller: testOwnerAddress,
+						PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqOoLR843vgkFGudQsjch
+2K85QJ4Hh7l2jjrMesQFDWVcW1xr//eieGzxDogWx7tMOtQ0hw77NAURhldek1Bh
+Co06790YHAE97JqgRQ+IR9Dl3GaGVQ2WcnknO4B1cvTRJmdsqrN1Bs4Qfd+jjKIM
+V1tz8zU9NmdR+DvGkAYYxoIx74YaTAxH+GCArfWMG1tRJPI9MELZbOWd9xkKlPic
+bLp8coZh9NgLajMDWKXpuHQ8cdJSxQ/ekZaTuEy7qbjbGBMVzbjhPjcxffQmGV1W
+gNY1BGplZz9mbBmH7siKnKIVZ5Bp55uLfEw+u2yOVx/0yKUdsmZoe4jhevCSq3aw
+GwIDAQAB
+-----END PUBLIC KEY-----`,
+					},
+					PubKey{
+						ID:         fmt.Sprintf("%s#keys-2", testOwnerAddress),
+						Type:       "RsaSignatureKey2018",
+						Controller: testOwnerAddress,
+						PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+Juw6xqYchTNFYUznmoB
+CzKfQG75v2Pv1Db1Z5EJgP6i0yRsBG1VqIOY4icRnyhDDVFi1omQjjUuCRxWGjsc
+B1UkSnybm0WC+g82HL3mUzbZja27NFJPuNaMaUlNbe0daOG88FS67jq5J2LsZH/V
+cGZBX5bbtCe0Niq39mQdJxdHq3D5ROMA73qeYvLkmXS6Dvs0w0fHsy+DwJtdOnOj
+xt4F5hIEXGP53qz2tBjCRL6HiMP/cLSwAd7oc67abgQxfnf9qldyd3X0IABpti1L
+irJNugfN6HuxHDm6dlXVReOhHRbkEcWedv82Ji5d/sDZ+WT+yWILOq03EJo/LXJ1
+SQIDAQAB
+-----END PUBLIC KEY-----`,
+					},
+				},
+			},
+			true,
+		},
+		{
+			"service invalid",
+			DidDocument{
+				ID:      testOwnerAddress,
+				Context: ContextDidV1,
+				PubKeys: PubKeys{
+					PubKey{
+						ID:         fmt.Sprintf("%s#keys-1", testOwnerAddress),
+						Type:       "RsaVerificationKey2018",
+						Controller: testOwnerAddress,
+						PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqOoLR843vgkFGudQsjch
+2K85QJ4Hh7l2jjrMesQFDWVcW1xr//eieGzxDogWx7tMOtQ0hw77NAURhldek1Bh
+Co06790YHAE97JqgRQ+IR9Dl3GaGVQ2WcnknO4B1cvTRJmdsqrN1Bs4Qfd+jjKIM
+V1tz8zU9NmdR+DvGkAYYxoIx74YaTAxH+GCArfWMG1tRJPI9MELZbOWd9xkKlPic
+bLp8coZh9NgLajMDWKXpuHQ8cdJSxQ/ekZaTuEy7qbjbGBMVzbjhPjcxffQmGV1W
+gNY1BGplZz9mbBmH7siKnKIVZ5Bp55uLfEw+u2yOVx/0yKUdsmZoe4jhevCSq3aw
+GwIDAQAB
+-----END PUBLIC KEY-----`,
+					},
+					PubKey{
+						ID:         fmt.Sprintf("%s#keys-2", testOwnerAddress),
+						Type:       "RsaSignatureKey2018",
+						Controller: testOwnerAddress,
+						PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+Juw6xqYchTNFYUznmoB
+CzKfQG75v2Pv1Db1Z5EJgP6i0yRsBG1VqIOY4icRnyhDDVFi1omQjjUuCRxWGjsc
+B1UkSnybm0WC+g82HL3mUzbZja27NFJPuNaMaUlNbe0daOG88FS67jq5J2LsZH/V
+cGZBX5bbtCe0Niq39mQdJxdHq3D5ROMA73qeYvLkmXS6Dvs0w0fHsy+DwJtdOnOj
+xt4F5hIEXGP53qz2tBjCRL6HiMP/cLSwAd7oc67abgQxfnf9qldyd3X0IABpti1L
+irJNugfN6HuxHDm6dlXVReOhHRbkEcWedv82Ji5d/sDZ+WT+yWILOq03EJo/LXJ1
+SQIDAQAB
+-----END PUBLIC KEY-----`,
+					},
+				},
+				Proof: &Proof{
+					Type:               KeyTypeSecp256k12019,
+					Created:            testTime,
+					ProofPurpose:       ProofPurposeAuthentication,
+					Controller:         testOwnerAddress.String(),
+					SignatureValue:     "uv9ZM4XusZl2q6Ei2O7aZW32pzwfg6ZQpBsQPb8cxzlFXWEyZLxem29fQBB4Py3W5gaXFEyPGruMXNsNDnr4sQ==",
+					VerificationMethod: "did:com:pub1addwnpepqwzc44ggn40xpwkfhcje9y7wdz6sunuv2uydxmqjrvcwff6npp2exy5dn6c",
+				},
+				Service: Services{
+					Service{},
+				},
+			},
+			true,
+		},
+		{
+			"all ok",
+			DidDocument{
+				Context: ContextDidV1,
+				ID:      testOwnerAddress,
+				Proof: &Proof{
+					Type:               KeyTypeSecp256k12019,
+					Created:            testTime,
+					ProofPurpose:       ProofPurposeAuthentication,
+					Controller:         testOwnerAddress.String(),
+					SignatureValue:     "uv9ZM4XusZl2q6Ei2O7aZW32pzwfg6ZQpBsQPb8cxzlFXWEyZLxem29fQBB4Py3W5gaXFEyPGruMXNsNDnr4sQ==",
+					VerificationMethod: "did:com:pub1addwnpepqwzc44ggn40xpwkfhcje9y7wdz6sunuv2uydxmqjrvcwff6npp2exy5dn6c",
+				},
+				PubKeys: PubKeys{
+					PubKey{
+						ID:         fmt.Sprintf("%s#keys-1", testOwnerAddress),
+						Type:       "RsaVerificationKey2018",
+						Controller: testOwnerAddress,
+						PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqOoLR843vgkFGudQsjch
+2K85QJ4Hh7l2jjrMesQFDWVcW1xr//eieGzxDogWx7tMOtQ0hw77NAURhldek1Bh
+Co06790YHAE97JqgRQ+IR9Dl3GaGVQ2WcnknO4B1cvTRJmdsqrN1Bs4Qfd+jjKIM
+V1tz8zU9NmdR+DvGkAYYxoIx74YaTAxH+GCArfWMG1tRJPI9MELZbOWd9xkKlPic
+bLp8coZh9NgLajMDWKXpuHQ8cdJSxQ/ekZaTuEy7qbjbGBMVzbjhPjcxffQmGV1W
+gNY1BGplZz9mbBmH7siKnKIVZ5Bp55uLfEw+u2yOVx/0yKUdsmZoe4jhevCSq3aw
+GwIDAQAB
+-----END PUBLIC KEY-----`,
+					},
+					PubKey{
+						ID:         fmt.Sprintf("%s#keys-2", testOwnerAddress),
+						Type:       "RsaSignatureKey2018",
+						Controller: testOwnerAddress,
+						PublicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+Juw6xqYchTNFYUznmoB
+CzKfQG75v2Pv1Db1Z5EJgP6i0yRsBG1VqIOY4icRnyhDDVFi1omQjjUuCRxWGjsc
+B1UkSnybm0WC+g82HL3mUzbZja27NFJPuNaMaUlNbe0daOG88FS67jq5J2LsZH/V
+cGZBX5bbtCe0Niq39mQdJxdHq3D5ROMA73qeYvLkmXS6Dvs0w0fHsy+DwJtdOnOj
+xt4F5hIEXGP53qz2tBjCRL6HiMP/cLSwAd7oc67abgQxfnf9qldyd3X0IABpti1L
+irJNugfN6HuxHDm6dlXVReOhHRbkEcWedv82Ji5d/sDZ+WT+yWILOq03EJo/LXJ1
+SQIDAQAB
+-----END PUBLIC KEY-----`,
+					},
+				},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.didDocument.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }

--- a/x/id/types/msgs_test.go
+++ b/x/id/types/msgs_test.go
@@ -29,7 +29,7 @@ func init() {
 	msgSetIdentity = types.NewMsgSetIdentity(types.DidDocument{
 		Context: types.ContextDidV1,
 		ID:      testOwnerAddress,
-		Proof: types.Proof{
+		Proof: &types.Proof{
 			Type:               types.KeyTypeSecp256k12019,
 			Created:            testTime,
 			ProofPurpose:       types.ProofPurposeAuthentication,

--- a/x/id/types/proof.go
+++ b/x/id/types/proof.go
@@ -47,6 +47,10 @@ func (proof Proof) Equals(other Proof) bool {
 // Validate checks for the content contained inside the proof and
 // returns an error if something is invalid
 func (proof Proof) Validate() error {
+	// proof is empty
+	if proof == (Proof{}) {
+		return sdkErr.Wrap(sdkErr.ErrUnauthorized, "empty proof")
+	}
 
 	if proof.Type != KeyTypeSecp256k12019 {
 		return sdkErr.Wrap(sdkErr.ErrUnknownRequest, fmt.Sprintf("Invalid proof type, must be %s", KeyTypeSecp256k12019))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Instead of relying on two different structs to physically split verified and unverified DID Documents, employ a logical separation and assert unverified data when calling `VerifyProof()`:

```go
type DidDocument struct {
        // ...
	// Proof is **NOT** optional, we need it to have omitempty to make the signature procedure more straightforward,
	// i.e. DidDocument.Validate() will check if proof is empty, and throw an error if true.
	Proof *Proof `json:"proof,omitempty"`
        // ...
}

// DidDocumentUnsigned is an intermediate type used to check for proof correctness
// It is identical to a DidDocument, it's kept for logical compartimentization.
type DidDocumentUnsigned DidDocument

func (didDocument DidDocument) VerifyProof() error {
	u := DidDocumentUnsigned(didDocument)

	// Explicitly zero out the Proof field.
	//
	// Here we leverage the fact that encoding/json do not encode nil pointers,
	// effectively giving us DidDocument-(Proof field).
	u.Proof = nil

        // ...
}
```

This is a quite radical change, but I added tests to cover message processing corner cases, as well as updates to CLI commands.

The motivation behind this change is the following: in the future we might want to add/remove fields from DidDocument, having an almost-identical copy minus the Proof field might lead to one struct getting updated while the other one isn't. 

## Checklist
- [x] Targeted PR against correct branch
- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For Admin Use:
- [x] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [x] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]"