### PR TITLE
x/docs: mark optional fields with "omitempty"

### DIFF
--- a/x/docs/internal/types/document.go
+++ b/x/docs/internal/types/document.go
@@ -18,10 +18,10 @@ type Document struct {
 	Recipients     types.Addresses         `json:"recipients"`
 	UUID           string                  `json:"uuid"`
 	Metadata       DocumentMetadata        `json:"metadata"`
-	ContentURI     string                  `json:"content_uri"`     // Optional
-	Checksum       *DocumentChecksum       `json:"checksum"`        // Optional
-	EncryptionData *DocumentEncryptionData `json:"encryption_data"` // Optional
-	DoSign         *DocumentDoSign         `json:"do_sign"`         // Optional
+	ContentURI     string                  `json:"content_uri,omitempty"`     // Optional
+	Checksum       *DocumentChecksum       `json:"checksum,omitempty"`        // Optional
+	EncryptionData *DocumentEncryptionData `json:"encryption_data,omitempty"` // Optional
+	DoSign         *DocumentDoSign         `json:"do_sign,omitempty"`         // Optional
 }
 
 // Equals returns true when doc equals other, false otherwise.

--- a/x/docs/internal/types/document_metadata.go
+++ b/x/docs/internal/types/document_metadata.go
@@ -20,8 +20,8 @@ func (metaSchema DocumentMetadataSchema) Equals(metSchema2 DocumentMetadataSchem
 // DocumentMetadata represents the information about the metadata associated to a document
 type DocumentMetadata struct {
 	ContentURI string                  `json:"content_uri"`
-	SchemaType string                  `json:"schema_type"` // Optional - Either this or schema must be defined
-	Schema     *DocumentMetadataSchema `json:"schema"`      // Optional - Either this or schema_type must be defined
+	SchemaType string                  `json:"schema_type,omitempty"` // Optional - Either this or schema must be defined
+	Schema     *DocumentMetadataSchema `json:"schema,omitempty"`      // Optional - Either this or schema_type must be defined
 }
 
 // Equals returns true iff this metadata and other contain the same data

--- a/x/docs/internal/types/document_receipt.go
+++ b/x/docs/internal/types/document_receipt.go
@@ -18,7 +18,7 @@ type DocumentReceipt struct {
 	Recipient    sdk.AccAddress `json:"recipient"`
 	TxHash       string         `json:"tx_hash"`
 	DocumentUUID string         `json:"document_uuid"`
-	Proof        string         `json:"proof"` // Optional
+	Proof        string         `json:"proof,omitempty"` // Optional
 }
 
 // Equals implements equatable

--- a/x/docs/internal/types/document_test.go
+++ b/x/docs/internal/types/document_test.go
@@ -435,7 +435,7 @@ func TestCreateDoc_DoSign(t *testing.T) {
 		{
 			"no do sign (null)",
 			nil,
-			"{\"sender\":\"\",\"recipients\":null,\"uuid\":\"uuid\",\"metadata\":{\"content_uri\":\"document_metadata_content_uri\",\"schema_type\":\"document_metadata_schema_type\",\"schema\":null},\"content_uri\":\"\",\"checksum\":null,\"encryption_data\":null,\"do_sign\":null}",
+			"{\"sender\":\"\",\"recipients\":null,\"uuid\":\"uuid\",\"metadata\":{\"content_uri\":\"document_metadata_content_uri\",\"schema_type\":\"document_metadata_schema_type\"}}",
 		},
 		{
 			"some data but empty sdn data",
@@ -446,7 +446,7 @@ func TestCreateDoc_DoSign(t *testing.T) {
 				VcrID:              "abc",
 				CertificateProfile: "abc",
 			},
-			"{\"sender\":\"\",\"recipients\":null,\"uuid\":\"uuid\",\"metadata\":{\"content_uri\":\"document_metadata_content_uri\",\"schema_type\":\"document_metadata_schema_type\",\"schema\":null},\"content_uri\":\"\",\"checksum\":null,\"encryption_data\":null,\"do_sign\":{\"storage_uri\":\"abc\",\"signer_instance\":\"abc\",\"sdn_data\":[],\"vcr_id\":\"abc\",\"certificate_profile\":\"abc\"}}",
+			"{\"sender\":\"\",\"recipients\":null,\"uuid\":\"uuid\",\"metadata\":{\"content_uri\":\"document_metadata_content_uri\",\"schema_type\":\"document_metadata_schema_type\"},\"do_sign\":{\"storage_uri\":\"abc\",\"signer_instance\":\"abc\",\"sdn_data\":[],\"vcr_id\":\"abc\",\"certificate_profile\":\"abc\"}}",
 		},
 		{
 			"all data",
@@ -464,7 +464,7 @@ func TestCreateDoc_DoSign(t *testing.T) {
 				VcrID:              "abc",
 				CertificateProfile: "abc",
 			},
-			"{\"sender\":\"\",\"recipients\":null,\"uuid\":\"uuid\",\"metadata\":{\"content_uri\":\"document_metadata_content_uri\",\"schema_type\":\"document_metadata_schema_type\",\"schema\":null},\"content_uri\":\"\",\"checksum\":null,\"encryption_data\":null,\"do_sign\":{\"storage_uri\":\"abc\",\"signer_instance\":\"abc\",\"sdn_data\":[\"common_name\",\"surname\",\"serial_number\",\"given_name\",\"organization\",\"country\"],\"vcr_id\":\"abc\",\"certificate_profile\":\"abc\"}}",
+			"{\"sender\":\"\",\"recipients\":null,\"uuid\":\"uuid\",\"metadata\":{\"content_uri\":\"document_metadata_content_uri\",\"schema_type\":\"document_metadata_schema_type\"},\"do_sign\":{\"storage_uri\":\"abc\",\"signer_instance\":\"abc\",\"sdn_data\":[\"common_name\",\"surname\",\"serial_number\",\"given_name\",\"organization\",\"country\"],\"vcr_id\":\"abc\",\"certificate_profile\":\"abc\"}}",
 		},
 	}
 


### PR DESCRIPTION
Without `omitempty` in the json tag, empty fields would unmarshal into either `null` or their type's zero value, breaking signature checks.

Without this change a client (e.g. a javascript one) that omits the `checksum` field would calculate a different signature than the node, failing the transaction.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Checklist
- [x] Targeted PR against correct branch
- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For Admin Use:
- [x] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [ ] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]"